### PR TITLE
Fix: Set working directory before running docs scripts.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,15 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies
-        run: npm ci
+        working-directory: ./frontend
+        run: npm install
+        env:
+          CI: ""
       - name: Build with VitePress
+        working-directory: ./frontend
         run: npm run docs:build
         env:
+          CI: ""
           DOCS_BASE_PATH: '/repo/'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Set working directory in docs action and temporarily set CI env to blank until ESLint warnings are addressed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
