### PR TITLE
Allow optional input mode for HPO/Training job input data configuration

### DIFF
--- a/frontend/src/entities/jobs/create.functions.ts
+++ b/frontend/src/entities/jobs/create.functions.ts
@@ -22,7 +22,6 @@ import {
     HyperParameterTuningJobConfigStrategy,
     IHPOJob,
     InputDataConfig,
-    InputDataConfigurationInputMode,
     IntegerParameterRange,
     ITrainingJobDefinition,
     OutputDataConfig,
@@ -49,7 +48,6 @@ export const createInputDataConfig = (): InputDataConfig & DatasetExtension => {
         ContentType: 'text/csv',
         CompressionType: CompressionType.None,
         RecordWrapperType: RecordWrapperType.None,
-        InputMode: InputDataConfigurationInputMode.File,
         Dataset: {
             Type: DatasetType.GLOBAL,
         },
@@ -184,6 +182,5 @@ export const createDefaultLabelingJob = (): ILabelingJobCreate => {
                 AnnotationConsolidationLambdaArn: '',
             },
         },
-        Tags: [],
     };
 };

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/input-data-configuration.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/input-data-configuration.tsx
@@ -254,7 +254,7 @@ export function Channel (props: ChannelProps) {
                         onBlur={() => touchFields(['ChannelName'])}
                     />
                 </FormField>
-                <FormField label='Input mode'>
+                <FormField label={<>Input mode - <em>optional</em></>}>
                     <Select
                         selectedOption={{ value: item.InputMode }}
                         options={enumToOptions(InputDataConfigurationInputMode)}

--- a/frontend/src/entities/jobs/hpo/hpo-job.model.ts
+++ b/frontend/src/entities/jobs/hpo/hpo-job.model.ts
@@ -99,7 +99,7 @@ export type InputDataConfig = {
     ContentType: string;
     CompressionType: CompressionType;
     RecordWrapperType: RecordWrapperType;
-    InputMode: InputDataConfigurationInputMode | InputDataConfigurationInputModeExpanded;
+    InputMode?: InputDataConfigurationInputMode | InputDataConfigurationInputModeExpanded;
     ShuffleConfig?: {
         Seed: number;
     };


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**
Updated HPO/Training jobs to allow the input mode to be optional for input data configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
