### PR TITLE
Updated dataset list_files in preparation for dataset UI improvements

### DIFF
--- a/backend/src/ml_space_lambda/utils/dict_utils.py
+++ b/backend/src/ml_space_lambda/utils/dict_utils.py
@@ -1,0 +1,27 @@
+def filter_dict(input: dict, allowed_keys: list[str]):
+    """
+    Returns a copy of input with keys not in allowed_keys removed
+
+    Args:
+        input (dict): A dict to filter
+        allowed_keys (list[str]): A list of allowed keys
+
+    Returns:
+        dict: A copy of input with only keys specified in allowed_keys
+    """
+    return {key: input.get(key) for key in allowed_keys if input.get(key) is not None}
+
+
+def map_dict_keys(input: dict, mapping: dict):
+    """
+    Returns a copy of input dict with the keys possible renamed using the
+    provided mapping dict. Unspecified keys will be unchanged.
+
+    Args:
+        input (dict): A dict with keys to rename
+        mapping (int): A dict of old key names to new key names
+
+    Returns:
+        dict: A copy of input with keys possibly renamed
+    """
+    return {mapping.get(key, key): input.get(key) for key in input}

--- a/backend/test/dataset/test_delete_dataset.py
+++ b/backend/test/dataset/test_delete_dataset.py
@@ -81,7 +81,7 @@ def test_delete_non_existent_dataset(mock_dataset_dao, mock_s3):
 
     assert lambda_handler(mock_event, mock_context) == expected_response
 
-    mock_bucket.objects.filter.not_called()
+    mock_bucket.objects.filter.assert_not_called()
     mock_dataset_dao.delete.assert_not_called()
 
 

--- a/backend/test/dataset/test_list_dataset_files.py
+++ b/backend/test/dataset/test_list_dataset_files.py
@@ -31,10 +31,10 @@ with mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True):
     from ml_space_lambda.dataset.lambda_functions import list_files as lambda_handler
 
 
-def build_mock_event(dataset: DatasetModel):
+def build_mock_event(dataset: DatasetModel, query: dict = {}):
     return {
         "pathParameters": {"scope": dataset.scope, "datasetName": dataset.name},
-        "queryStringParameters": None,
+        "queryStringParameters": query,
     }
 
 
@@ -43,28 +43,126 @@ def build_mock_event(dataset: DatasetModel):
 def test_list_dataset_files_success(mock_s3, mock_dataset_dao, mock_global_dataset):
     mock_dataset_dao.get.return_value = mock_global_dataset
     mock_s3.list_objects_v2.return_value = {
+        "Prefix": "global/datasets/example_dataset/",
+        "MaxKeys": 1000,
         "Contents": [
             {"Key": "global/datasets/example_dataset/file1.txt", "Size": 643},
             {"Key": "global/datasets/example_dataset/file2.png", "Size": 1243},
+        ],
+        "CommonPrefixes": [
+            {"Prefix": "global/datasets/example_dataset/nested"}
         ]
     }
 
     expected_response = generate_html_response(
         200,
         {
-            "Keys": [
+            "pageSize": 1000,
+            "prefix": "global/datasets/example_dataset/",
+            "contents": [
+                {"key": "global/datasets/example_dataset/file1.txt", "size": 643},
+                {"key": "global/datasets/example_dataset/file2.png", "size": 1243},
+                {"prefix": "global/datasets/example_dataset/nested"},
+            ],
+        },
+    )
+
+    assert lambda_handler(build_mock_event(mock_global_dataset), mock_context) == expected_response\
+
+    mock_s3.list_objects_v2.assert_called_with(
+        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/", Delimiter="/"
+    )
+    mock_dataset_dao.get.assert_called_with(mock_global_dataset.scope, mock_global_dataset.name)
+
+
+@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
+@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
+def test_list_dataset_files_success_with_prefix(mock_s3, mock_dataset_dao, mock_global_dataset):
+    mock_dataset_dao.get.return_value = mock_global_dataset
+    mock_s3.list_objects_v2.return_value = {
+        "MaxKeys": 1000,
+        "Prefix": "global/datasets/example_dataset/nested/",
+        "Contents": [
+            {"Key": "global/datasets/example_dataset/nested/file3.txt", "Size": 346},
+            {"Key": "global/datasets/example_dataset/nested/file4.png", "Size": 3421},
+        ],
+    }
+
+    expected_response = generate_html_response(
+        200,
+        {
+            "pageSize": 1000,
+            "prefix": "global/datasets/example_dataset/nested/",
+            "contents": [
+                {"key": "global/datasets/example_dataset/nested/file3.txt", "size": 346},
+                {"key": "global/datasets/example_dataset/nested/file4.png", "size": 3421},
+            ],
+        },
+    )
+
+    assert lambda_handler(build_mock_event(mock_global_dataset, {"prefix": "nested/"}), mock_context) == expected_response
+    mock_s3.list_objects_v2.assert_called_with(
+        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/nested/", Delimiter="/"
+    )
+
+@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
+@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
+def test_list_dataset_files_success_with_page_size(mock_s3, mock_dataset_dao, mock_global_dataset):
+    mock_dataset_dao.get.return_value = mock_global_dataset
+    mock_s3.list_objects_v2.return_value = {
+        "Prefix": "global/datasets/example_dataset/",
+        "MaxKeys": 1000,
+        "Contents": [
+            {"Key": "global/datasets/example_dataset/file1.txt", "Size": 643},
+            {"Key": "global/datasets/example_dataset/file2.png", "Size": 1243},
+        ],
+    }
+
+    expected_response = generate_html_response(
+        200,
+        {
+            "pageSize": 1000,
+            "prefix": "global/datasets/example_dataset/",
+            "contents": [
                 {"key": "global/datasets/example_dataset/file1.txt", "size": 643},
                 {"key": "global/datasets/example_dataset/file2.png", "size": 1243},
             ],
         },
     )
 
-    assert lambda_handler(build_mock_event(mock_global_dataset), mock_context) == expected_response
-
+    assert lambda_handler(build_mock_event(mock_global_dataset, {"pageSize": 2}), mock_context) == expected_response
     mock_s3.list_objects_v2.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/"
+        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/", Delimiter="/", MaxKeys=2
     )
-    mock_dataset_dao.get.assert_called_with(mock_global_dataset.scope, mock_global_dataset.name)
+
+
+@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
+@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
+def test_list_dataset_files_success_with_next_token(mock_s3, mock_dataset_dao, mock_global_dataset):
+    mock_dataset_dao.get.return_value = mock_global_dataset
+    mock_s3.list_objects_v2.return_value = {
+        "MaxKeys": 1000,
+        "Prefix": "global/datasets/example_dataset/",
+        "Contents": [
+            {"Key": "global/datasets/example_dataset/file5.txt", "Size": 789},
+        ],
+    }
+
+    expected_response = generate_html_response(
+        200,
+        {
+            "pageSize": 1000,
+            "prefix": "global/datasets/example_dataset/",
+            "contents": [
+                {"key": "global/datasets/example_dataset/file5.txt", "size": 789},
+            ],
+        },
+    )
+
+    assert lambda_handler(build_mock_event(mock_global_dataset, {"nextToken": "abc123"}), mock_context) == expected_response
+    mock_s3.list_objects_v2.assert_called_with(
+        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/", Delimiter="/", ContinuationToken="abc123"
+    )
 
 
 @mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
@@ -72,74 +170,23 @@ def test_list_dataset_files_success(mock_s3, mock_dataset_dao, mock_global_datas
 def test_list_dataset_files_empty(mock_s3, mock_dataset_dao, mock_global_dataset):
     mock_dataset_dao.get.return_value = mock_global_dataset
     mock_s3.list_objects_v2.return_value = {
-        "Contents": [
-            {"Key": "global/datasets/example_dataset/", "Size": 0},
-        ]
+        "Prefix": "global/datasets/example_dataset/",
+        "MaxKeys": 1000,
     }
 
     expected_response = generate_html_response(
         200,
         {
-            "Keys": [],
+            "pageSize": 1000,
+            "prefix": "global/datasets/example_dataset/",
+            "contents": [],
         },
     )
 
-    assert lambda_handler(build_mock_event(mock_global_dataset), mock_context) == expected_response
+    assert lambda_handler(build_mock_event(mock_global_dataset), mock_context) == expected_response\
 
     mock_s3.list_objects_v2.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/"
-    )
-    mock_dataset_dao.get.assert_called_with(mock_global_dataset.scope, mock_global_dataset.name)
-
-
-@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
-@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
-def test_list_dataset_files_success_next_token(mock_s3, mock_dataset_dao, mock_global_dataset):
-    mock_dataset_dao.get.return_value = mock_global_dataset
-    mock_s3.list_objects_v2.return_value = {
-        "Contents": [
-            {"Key": "global/datasets/example_dataset/file1.txt", "Size": 643},
-            {"Key": "global/datasets/example_dataset/file2.png", "Size": 1243},
-        ],
-        "NextContinuationToken": "continueNextToken",
-    }
-
-    expected_response = generate_html_response(
-        200,
-        {
-            "Keys": [
-                {"key": "global/datasets/example_dataset/file1.txt", "size": 643},
-                {"key": "global/datasets/example_dataset/file2.png", "size": 1243},
-            ],
-            "nextToken": "continueNextToken",
-        },
-    )
-
-    mock_event = build_mock_event(mock_global_dataset)
-    mock_event["queryStringParameters"] = {
-        "nextToken": "nextTokenExample",
-    }
-    assert lambda_handler(mock_event, mock_context) == expected_response
-
-    mock_s3.list_objects_v2.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"],
-        Prefix="global/datasets/example_dataset/",
-        ContinuationToken="nextTokenExample",
-    )
-    mock_dataset_dao.get.assert_called_with(mock_global_dataset.scope, mock_global_dataset.name)
-
-
-@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
-@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
-def test_list_dataset_files_empty_dataset(mock_s3, mock_dataset_dao, mock_global_dataset):
-    mock_dataset_dao.get.return_value = mock_global_dataset
-    mock_s3.list_objects_v2.return_value = {}
-    expected_response = generate_html_response(200, {"Keys": []})
-
-    assert lambda_handler(build_mock_event(mock_global_dataset), mock_context) == expected_response
-
-    mock_s3.list_objects_v2.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/"
+        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/", Delimiter="/"
     )
     mock_dataset_dao.get.assert_called_with(mock_global_dataset.scope, mock_global_dataset.name)
 
@@ -164,7 +211,7 @@ def test_list_dataset_files_client_error(mock_s3, mock_dataset_dao, mock_global_
     assert lambda_handler(build_mock_event(mock_global_dataset), mock_context) == expected_response
 
     mock_s3.list_objects_v2.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/"
+        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"], Prefix="global/datasets/example_dataset/", Delimiter="/"
     )
     mock_dataset_dao.get.assert_called_with(mock_global_dataset.scope, mock_global_dataset.name)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated dataset list_files in preparation for dataset UI improvements

- updated response format to include more of the content from s3
 - response now combines objects and common prefixes in "contents" field
 - includes prefix used for query
 - includes "isTruncated", "keyCount", and "pageSize" response from query

**new response**
```json
# GET /dataset/global/NISTData/files?prefix=test%2F&nextToken=123abc&pageSize=3
{
    "isTruncated": true,
    "pageSize": 3,
    "keyCount": 3,
    "nextToken": "456def",
    "prefix": "global/datasets/NISTData/test/",
    "contents": [
      {"Key": "global/datasets/NISTData/test/file1", "Size": 100},
      {"Key": "global/datasets/NISTData/test/file1", "Size": 200},
      {"Prefix": "global/datasets/NISTData/test/nested"}
    ]
}
```

**old response**
```json
# GET /dataset/global/NISTData/files?nextToken=123abc
{
    "Keys": [
      {"Key": "global/datasets/NISTData/file1"},
      {"Key": "global/datasets/NISTData/file2"},
      {"Key": "global/datasets/NISTData/nested/file3"},
      {"Key": "global/datasets/NISTData/nested/file4"},
      {"Key": "global/datasets/NISTData/nested/another/file5"},
      {"Key": "global/datasets/NISTData/nested/another/file6"},
    ],
    "nextToken": "abcdefghijklmnop"
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
