### PR TITLE
Remove put_objects line so datasets create correctly

### DIFF
--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -197,7 +197,6 @@ def create_dataset(event, context):
         raise Exception("Dataset headers do not match expected type and scope.")
 
     if not dataset_dao.get(scope, dataset_name):
-        s3.put_object(Bucket=env_variables["DATA_BUCKET"], Key=directory_name)
         dataset_location = f's3://{env_variables["DATA_BUCKET"]}/{directory_name}'
         dataset = DatasetModel(
             scope=scope,

--- a/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
+++ b/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
@@ -96,9 +96,9 @@ def create(event, context):
 
     labeling_job["HumanTaskConfig"]["PreHumanTaskLambdaArn"] = get_groundtruth_lambda_arn(LambdaTypes.PRE, task_type)
 
-    labeling_job["HumanTaskConfig"]["AnnotationConsolidationConfig"][
-        "AnnotationConsolidationLambdaArn"
-    ] = get_groundtruth_lambda_arn(LambdaTypes.ACS, task_type)
+    labeling_job["HumanTaskConfig"]["AnnotationConsolidationConfig"]["AnnotationConsolidationLambdaArn"] = (
+        get_groundtruth_lambda_arn(LambdaTypes.ACS, task_type)
+    )
 
     template_uri = generate_ui_template(
         labeling_job_name,

--- a/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
+++ b/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
@@ -96,9 +96,9 @@ def create(event, context):
 
     labeling_job["HumanTaskConfig"]["PreHumanTaskLambdaArn"] = get_groundtruth_lambda_arn(LambdaTypes.PRE, task_type)
 
-    labeling_job["HumanTaskConfig"]["AnnotationConsolidationConfig"]["AnnotationConsolidationLambdaArn"] = (
-        get_groundtruth_lambda_arn(LambdaTypes.ACS, task_type)
-    )
+    labeling_job["HumanTaskConfig"]["AnnotationConsolidationConfig"][
+        "AnnotationConsolidationLambdaArn"
+    ] = get_groundtruth_lambda_arn(LambdaTypes.ACS, task_type)
 
     template_uri = generate_ui_template(
         labeling_job_name,

--- a/backend/test/dataset/test_create_dataset.py
+++ b/backend/test/dataset/test_create_dataset.py
@@ -18,7 +18,6 @@ import json
 from unittest import mock
 
 import pytest
-from botocore.exceptions import ClientError
 
 from ml_space_lambda.data_access_objects.dataset import DatasetModel
 from ml_space_lambda.enums import DatasetType
@@ -91,21 +90,17 @@ def test_create_dataset_success(mock_s3, mock_dataset_dao, dataset_type: str, sc
 
     dataset_location = f's3://{TEST_ENV_CONFIG["DATA_BUCKET"]}/{directory_name}'
 
-    test_dataset = generate_dataset_model(event=mock_event, scope=scope, dataset_location=dataset_location)
+    test_dataset = generate_dataset_model(
+        event=mock_event, scope=scope, dataset_location=dataset_location
+    )
     success_response = {"status": "success", "dataset": test_dataset.to_dict()}
     expected_response = generate_html_response(200, success_response)
 
     assert lambda_handler(mock_event, mock_context) == expected_response
 
-    mock_s3.put_object.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"],
-        Key=directory_name,
-    )
-
 
 @mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
-@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
-def test_create_dataset_already_exists(mock_s3, mock_dataset_dao):
+def test_create_dataset_already_exists(mock_dataset_dao):
     scope = "global"
     mock_event = generate_event(DatasetType.GLOBAL.value, scope)
     mock_dataset_dao.get.return_value = True
@@ -114,57 +109,29 @@ def test_create_dataset_already_exists(mock_s3, mock_dataset_dao):
     expected_response = generate_html_response(400, error_message)
 
     assert lambda_handler(mock_event, mock_context) == expected_response
-    mock_s3.put_object.assert_not_called()
 
 
-@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
-@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
-def test_create_dataset_client_error(mock_s3, mock_dataset_dao):
-    scope = "global"
-    directory_name = f"{scope}/datasets/{test_dataset_name}/"
-    mock_event = generate_event(DatasetType.GLOBAL.value, scope)
-
-    error_msg = {
-        "Error": {"Code": "ThrottlingException", "Message": "Dummy error message."},
-        "ResponseMetadata": {"HTTPStatusCode": 400},
-    }
-    expected_response = generate_html_response(
-        400,
-        "An error occurred (ThrottlingException) when calling the GeneratePresignedUrl operation: " "Dummy error message.",
-    )
-    mock_dataset_dao.get.return_value = None
-    mock_s3.put_object.side_effect = ClientError(error_msg, "GeneratePresignedUrl")
-
-    assert lambda_handler(mock_event, mock_context) == expected_response
-
-    mock_s3.put_object.assert_called_with(
-        Bucket=TEST_ENV_CONFIG["DATA_BUCKET"],
-        Key=directory_name,
-    )
-
-
-@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
-def test_create_dataset_manipulated_type(mock_s3):
+def test_create_dataset_manipulated_type():
     scope = "global"
     mock_event = generate_event(DatasetType.GLOBAL.value, scope)
     mock_event["headers"] = {"x-mlspace-dataset-type": "private", "x-mlspace-dataset-scope": scope}
 
-    expected_response = generate_html_response(400, "Bad Request: Dataset headers do not match expected type and scope.")
+    expected_response = generate_html_response(
+        400, "Bad Request: Dataset headers do not match expected type and scope."
+    )
 
     assert lambda_handler(mock_event, mock_context) == expected_response
 
-    mock_s3.put_object.assert_not_called()
 
-
-@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
-def test_create_dataset_manipulated_scope(mock_s3):
+def test_create_dataset_manipulated_scope():
     scope = "global"
 
     mock_event = generate_event(DatasetType.GLOBAL.value, scope)
     mock_event["headers"] = {"x-mlspace-dataset-type": "private", "x-mlspace-dataset-scope": "jdoe"}
 
-    expected_response = generate_html_response(400, "Bad Request: Dataset headers do not match expected type and scope.")
+    expected_response = generate_html_response(
+        400, "Bad Request: Dataset headers do not match expected type and scope."
+    )
 
     assert lambda_handler(mock_event, mock_context) == expected_response
 
-    mock_s3.put_object.assert_not_called()

--- a/backend/test/dataset/test_create_dataset.py
+++ b/backend/test/dataset/test_create_dataset.py
@@ -90,9 +90,7 @@ def test_create_dataset_success(mock_s3, mock_dataset_dao, dataset_type: str, sc
 
     dataset_location = f's3://{TEST_ENV_CONFIG["DATA_BUCKET"]}/{directory_name}'
 
-    test_dataset = generate_dataset_model(
-        event=mock_event, scope=scope, dataset_location=dataset_location
-    )
+    test_dataset = generate_dataset_model(event=mock_event, scope=scope, dataset_location=dataset_location)
     success_response = {"status": "success", "dataset": test_dataset.to_dict()}
     expected_response = generate_html_response(200, success_response)
 
@@ -116,9 +114,7 @@ def test_create_dataset_manipulated_type():
     mock_event = generate_event(DatasetType.GLOBAL.value, scope)
     mock_event["headers"] = {"x-mlspace-dataset-type": "private", "x-mlspace-dataset-scope": scope}
 
-    expected_response = generate_html_response(
-        400, "Bad Request: Dataset headers do not match expected type and scope."
-    )
+    expected_response = generate_html_response(400, "Bad Request: Dataset headers do not match expected type and scope.")
 
     assert lambda_handler(mock_event, mock_context) == expected_response
 
@@ -129,9 +125,6 @@ def test_create_dataset_manipulated_scope():
     mock_event = generate_event(DatasetType.GLOBAL.value, scope)
     mock_event["headers"] = {"x-mlspace-dataset-type": "private", "x-mlspace-dataset-scope": "jdoe"}
 
-    expected_response = generate_html_response(
-        400, "Bad Request: Dataset headers do not match expected type and scope."
-    )
+    expected_response = generate_html_response(400, "Bad Request: Dataset headers do not match expected type and scope.")
 
     assert lambda_handler(mock_event, mock_context) == expected_response
-


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Datasets should be not be created using the put_object function; this is resulting in the deletion of dataset "files" deleting the entire dataset itself.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
