### PR TITLE
[AIML-ADC-6764] Support the ability to specify a subnet as part of EMR Cluster creation

### DIFF
--- a/backend/test/emr/test_create_emr_cluster.py
+++ b/backend/test/emr/test_create_emr_cluster.py
@@ -157,7 +157,7 @@ def _expected_args(custom_ami: Optional[str] = None):
             "Ec2KeyName": mock_cluster_config["ec2-key"],
             "KeepJobFlowAliveWhenNoSteps": True,
             "TerminationProtected": False,
-            "Ec2SubnetIds": ["example_subnet1", "example_subnet2", "example_subnet3"],
+            "Ec2SubnetId": "subnet1",
         },
         "VisibleToAllUsers": True,
         "JobFlowRole": TEST_ENV_CONFIG["EMR_EC2_ROLE_NAME"],
@@ -190,7 +190,7 @@ def _mock_event_body(custom_ami: Optional[str] = None):
     return {
         "clusterName": "example_cluster_name",
         "options": options,
-        "subnetIds": "example_subnet1,example_subnet2,example_subnet3",
+        "Instances": {"Ec2SubnetId": "subnet1"},
     }
 
 
@@ -233,7 +233,6 @@ def _mock_args(random_subnet: Optional[str] = None, custom_ami: Optional[str] = 
     call_args = copy.deepcopy(_expected_args(custom_ami=custom_ami))
     if random_subnet:
         call_args["Instances"]["Ec2SubnetId"] = random_subnet
-        del call_args["Instances"]["Ec2SubnetIds"]
 
     return call_args
 
@@ -241,7 +240,7 @@ def _mock_args(random_subnet: Optional[str] = None, custom_ami: Optional[str] = 
 def _mock_event(include_subnet: Optional[bool] = True, custom_ami: Optional[str] = None):
     event_body = copy.deepcopy(_mock_event_body(custom_ami=custom_ami))
     if not include_subnet:
-        del event_body["subnetIds"]
+        event_body["Instances"]["Ec2SubnetId"] = ""
 
     return {
         "body": json.dumps(event_body),

--- a/backend/test/emr/test_create_emr_cluster.py
+++ b/backend/test/emr/test_create_emr_cluster.py
@@ -178,7 +178,7 @@ def _expected_args(custom_ami: Optional[str] = None):
     return expected_args
 
 
-def _mock_event_body(custom_ami: Optional[str] = None):
+def _mock_event_body(subnet: Optional[str] = "", custom_ami: Optional[str] = None):
     options = {
         "emrSize": "example_emr_size",
         "applications": ["Hive", "HBase"],
@@ -190,7 +190,7 @@ def _mock_event_body(custom_ami: Optional[str] = None):
     return {
         "clusterName": "example_cluster_name",
         "options": options,
-        "Instances": {"Ec2SubnetId": "subnet1"},
+        "Instances": {"Ec2SubnetId": subnet},
     }
 
 
@@ -229,18 +229,16 @@ mock_list_response = {
 }
 
 
-def _mock_args(random_subnet: Optional[str] = None, custom_ami: Optional[str] = None):
+def _mock_args(specific_subnet: Optional[str] = None, custom_ami: Optional[str] = None):
     call_args = copy.deepcopy(_expected_args(custom_ami=custom_ami))
-    if random_subnet:
-        call_args["Instances"]["Ec2SubnetId"] = random_subnet
+    if specific_subnet:
+        call_args["Instances"]["Ec2SubnetId"] = specific_subnet
 
     return call_args
 
 
-def _mock_event(include_subnet: Optional[bool] = True, custom_ami: Optional[str] = None):
-    event_body = copy.deepcopy(_mock_event_body(custom_ami=custom_ami))
-    if not include_subnet:
-        event_body["Instances"]["Ec2SubnetId"] = ""
+def _mock_event(subnet: Optional[str] = "", custom_ami: Optional[str] = None):
+    event_body = copy.deepcopy(_mock_event_body(subnet=subnet, custom_ami=custom_ami))
 
     return {
         "body": json.dumps(event_body),
@@ -296,12 +294,63 @@ def test_create_emr_cluster_success(
 
     expected_response = generate_html_response(200, mock_response)
 
-    assert emr_handler.create(_mock_event(include_subnet=False, custom_ami=mock_ami_id), mock_context) == expected_response
+    assert emr_handler.create(_mock_event(subnet="", custom_ami=mock_ami_id), mock_context) == expected_response
 
-    mock_emr.run_job_flow.assert_called_with(**_mock_args(random_subnet=mocked_random_subnet, custom_ami=mock_ami_id))
+    mock_emr.run_job_flow.assert_called_with(**_mock_args(specific_subnet=mocked_random_subnet, custom_ami=mock_ami_id))
     mock_pull_config.assert_called_once()
     mock_s3.get_object.assert_called_with(Bucket="example_bucket", Key="cluster-config.json")
 
+    cluster_schedule = mock_resource_scheduler_dao.create.call_args.args[0]
+    assert cluster_schedule.resource_id == mock_cluster_id
+    assert cluster_schedule.resource_type == ResourceType.EMR_CLUSTER
+    # We're mocking a termination time of 3 days so ensure the termination time makes sense
+    assert cluster_schedule.termination_time > (time.time() + (71 * 60 * 60))
+    assert cluster_schedule.project == mock_project.name
+
+
+@mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True)
+@mock.patch("ml_space_lambda.emr.lambda_functions.resource_scheduler_dao")
+@mock.patch("ml_space_lambda.emr.lambda_functions.project_dao")
+@mock.patch("ml_space_lambda.emr.lambda_functions.s3")
+@mock.patch("ml_space_lambda.emr.lambda_functions.pull_config_from_s3")
+@mock.patch("ml_space_lambda.emr.lambda_functions.emr")
+def test_create_emr_cluster_success_with_subnet(
+    mock_emr,
+    mock_pull_config,
+    mock_s3,
+    mock_project_dao,
+    mock_resource_scheduler_dao,
+):
+    # This test checks to see that the response contains the expected subnet that the user specifies.
+
+    # clear out global config if set to make lambda tests independent of each other
+    mlspace_config.param_file = {}
+    mlspace_config.env_variables = {}
+    emr_handler.cluster_config = {}
+
+    specific_subnet = "ThisIsASpecificSubnet1"
+    mock_ami_id = "ami-123456789"
+
+    mock_s3.get_object.return_value = copy.deepcopy(mock_cluster_config_response)
+    mock_emr.run_job_flow.return_value = mock_response
+    mock_paginator = mock.MagicMock()
+    mock_emr.get_paginator.return_value = mock_paginator
+    mock_cluster_id = "Cluster1"
+    mock_paginator.paginate.return_value = [
+        {"Clusters": [{"Id": mock_cluster_id, "Name": f"{MOCK_PROJECT_NAME}-{MOCK_CLUSTER_NAME}"}]}
+    ]
+    mock_project_dao.get.return_value = mock_project
+
+    expected_response = generate_html_response(200, mock_response)
+
+    assert emr_handler.create(_mock_event(subnet=specific_subnet, custom_ami=mock_ami_id), mock_context) == expected_response
+
+    # Check it had correct parameters and subnet was passed in
+    mock_emr.run_job_flow.assert_called_with(**_mock_args(specific_subnet=specific_subnet, custom_ami=mock_ami_id))
+    mock_pull_config.assert_not_called()
+    mock_s3.get_object.assert_called_with(Bucket="example_bucket", Key="cluster-config.json")
+
+    # Check it was created successfully
     cluster_schedule = mock_resource_scheduler_dao.create.call_args.args[0]
     assert cluster_schedule.resource_id == mock_cluster_id
     assert cluster_schedule.resource_type == ResourceType.EMR_CLUSTER
@@ -329,14 +378,16 @@ def test_create_emr_cluster_client_error(mock_emr, mock_pull_config, mock_s3):
         "An error occurred (MissingParameter) when calling the RunJobFlow operation: Dummy error message.",
     )
 
+    specific_subnet = "ADifferentSubnet"
+
     mock_s3.get_object.return_value = copy.deepcopy(mock_cluster_config_response)
     mock_emr.run_job_flow.side_effect = ClientError(error_msg, "RunJobFlow")
 
-    assert emr_handler.create(_mock_event(), mock_context) == expected_response
+    assert emr_handler.create(_mock_event(subnet=specific_subnet), mock_context) == expected_response
 
     mock_pull_config.assert_not_called()
     mock_s3.get_object.assert_called_with(Bucket="example_bucket", Key="cluster-config.json")
-    error_args = _mock_args()
+    error_args = _mock_args(specific_subnet=specific_subnet)
     mock_emr.run_job_flow.assert_called_with(**error_args)
 
 

--- a/frontend/src/entities/emr/create/emr-cluster-create.tsx
+++ b/frontend/src/entities/emr/create/emr-cluster-create.tsx
@@ -31,7 +31,7 @@ import {
 } from '@cloudscape-design/components';
 import { useNavigate, useParams } from 'react-router-dom';
 import z from 'zod';
-import { useAppDispatch } from '../../../config/store';
+import { useAppDispatch, useAppSelector } from '../../../config/store';
 import NotificationService from '../../../shared/layout/notification/notification.service';
 import { issuesToErrors, scrollToInvalid, useValidationReducer } from '../../../shared/validation';
 import { createEMRCluster } from '../emr.reducer';
@@ -42,6 +42,9 @@ import { generateNameConstraintTextWithProject } from '../../../shared/util/form
 import { useState } from 'react';
 import { enumToOptions } from '../../../shared/util/enum-utils';
 import Condition from '../../../modules/condition';
+import { listSubnets, selectSubnets } from '../../../shared/metadata/metadata.reducer';
+import { Subnet } from '../../../shared/model/vpc.config';
+import { LoadingStatus } from '../../../shared/loading-status';
 
 enum ClusterAmi {
     BUILT_IN = 'built-in',
@@ -54,6 +57,7 @@ export default function EMRClusterCreate () {
     const basePath = `/project/${projectName}/emr`;
     const dispatch = useAppDispatch();
     const notificationService = NotificationService(dispatch);
+    const subnets = useAppSelector(selectSubnets);
     const [clusterAmi, setClusterAmi] = useState(ClusterAmi.BUILT_IN);
 
     const formSchema = z.object({
@@ -92,6 +96,9 @@ export default function EMRClusterCreate () {
                 emrSize: 'Small',
                 emrRelease: 'emr-6.2.0',
             },
+            Instances: {
+                Ec2SubnetId: ''
+            }
         },
     });
 
@@ -112,10 +119,13 @@ export default function EMRClusterCreate () {
                 { text: 'Create EMR Cluster', href: `#${basePath}/create` },
             ])
         );
+        if (subnets.status === LoadingStatus.INITIAL) {
+            dispatch(listSubnets());
+        }
 
         scrollToPageHeader('h1', 'Create EMR Cluster');
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [dispatch, basePath, projectName]);
+    }, [dispatch, basePath, projectName, subnets.status]);
 
     const handleSubmit = () => {
         setState({ formSubmitting: true });
@@ -203,6 +213,31 @@ export default function EMRClusterCreate () {
                                     onBlur={() => touchFields(['clusterName'])}
                                 />
                             </FormField>
+                            <ExpandableSection headerText='Advanced network settings' headingTagOverride='h3'>
+                                <FormField
+                                    label='Subnet(s)'
+                                    description='Choose a subnet in an availability zone supported by Amazon SageMaker.'
+                                >
+                                    <Select
+                                        selectedOption={{label: state.form.Instances?.Ec2SubnetId, value:state.form.Instances?.Ec2SubnetId}}
+                                        onChange={({ detail }) => {
+                                            setFields({
+                                                'Instances.Ec2SubnetId': detail.selectedOption.value
+                                            });
+                                        }}
+                                        options={(subnets?.values || []).map((subnet: Subnet) => {
+                                            return {
+                                                label: subnet.subnetId,
+                                                value: subnet.subnetId,
+                                                description: subnet.availabilityZone,
+                                            };
+                                        })}
+                                        placeholder='Choose option'
+                                        loadingText='Loading subnet(s)'
+                                    />
+                                </FormField>
+                            </ExpandableSection>
+                            
                         </Grid>
                     </Container>
 

--- a/frontend/src/entities/emr/create/emr-cluster-create.tsx
+++ b/frontend/src/entities/emr/create/emr-cluster-create.tsx
@@ -216,7 +216,7 @@ export default function EMRClusterCreate () {
                             <ExpandableSection headerText='Advanced network settings' headingTagOverride='h3'>
                                 <FormField
                                     label='Subnet(s)'
-                                    description='Choose a subnet in an availability zone supported by Amazon SageMaker.'
+                                    description='Choose a subnet in an availability zone supported by EMR.'
                                 >
                                     <Select
                                         selectedOption={{label: state.form.Instances?.Ec2SubnetId, value:state.form.Instances?.Ec2SubnetId}}

--- a/frontend/src/entities/emr/detail/emr-clusters-detail.tsx
+++ b/frontend/src/entities/emr/detail/emr-clusters-detail.tsx
@@ -71,6 +71,8 @@ function EMRDetail () {
     clusterSummary.set('Creation time', formatDate(cluster?.Status?.Timeline?.CreationDateTime));
     clusterSummary.set('Ready time', formatDate(cluster?.Status?.Timeline?.ReadyDateTime));
     clusterSummary.set('Release label', cluster?.ReleaseLabel);
+    clusterSummary.set('Subnet', cluster?.Ec2InstanceAttributes?.Ec2SubnetId);
+
     if (project.metadata?.terminationConfiguration?.defaultEMRClusterTTL) {
         clusterSummary.set(
             'Auto termination time',

--- a/frontend/src/entities/emr/emr.model.ts
+++ b/frontend/src/entities/emr/emr.model.ts
@@ -52,6 +52,7 @@ type EMRClusterFull = {
         IamInstanceProfile: string;
         Ec2KeyName: string;
         Ec2AvailabilityZone: string;
+        Ec2SubnetId: string;
         EmrManagedSlaveSecurityGroup: string;
     };
     Name: string;


### PR DESCRIPTION
*Issue #, if available:* AIML-ADC-6764

*Description of changes:*

- Add Advanced Network tab during EMR creation
- Handle passed in subnet in lambda function
- Pick random subnet if none specified
- Update EMR details page to display subnet


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
