### PR TITLE
Fix linting of frontend, address existing issues that snuck in

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": 12,
-        "sourceType": "module",
+        "sourceType": "module"
     },
     "plugins": [
         "@stylistic",
@@ -135,6 +135,7 @@
                     "debounce",
                     "debounced",
                     "decrypt",
+                    "deeplab",
                     "depthwise",
                     "deterministically",
                     "dhcp",
@@ -164,6 +165,7 @@
                     "eps",
                     "evenodd",
                     "faiss",
+                    "fcn",
                     "fjlt",
                     "flashbar",
                     "func",
@@ -248,6 +250,7 @@
                     "preflight",
                     "presigned",
                     "pretrained",
+                    "psp",
                     "quantile",
                     "quantiles",
                     "randomcutforest",
@@ -259,6 +262,7 @@
                     "rescale",
                     "rescaling",
                     "resize",
+                    "resnet",
                     "retryable",
                     "revalidate",
                     "rmse",

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,0 +1,65 @@
+{
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 12,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@stylistic",
+        "@typescript-eslint",
+        "spellcheck"
+    ],
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:react-hooks/recommended",
+        "plugin:react/recommended"
+    ],
+    "rules": {
+        "eqeqeq": [
+            "error",
+            "smart"
+        ],
+        "@stylistic/indent": "error",
+        "@stylistic/quotes": [
+            "error",
+            "single"
+        ],
+        "@stylistic/arrow-parens": "error",
+        "@stylistic/arrow-spacing": "error",
+        "@stylistic/brace-style": "error",
+        "@stylistic/computed-property-spacing": [
+            "error",
+            "never"
+        ],
+        "@stylistic/jsx-quotes": [
+            "error",
+            "prefer-single"
+        ],
+        "@stylistic/keyword-spacing": [
+            "error",
+            {
+                "before": true
+            }
+        ],
+        "@stylistic/semi": "error",
+        "@stylistic/space-before-function-paren": "error",
+        "@stylistic/space-infix-ops": "error",
+        "@stylistic/space-unary-ops": "error",
+        "@typescript-eslint/no-unused-vars": "error",
+        // to enforce using type for object type definitions, can be type or interface
+        "@typescript-eslint/consistent-type-definitions": [
+            "error",
+            "type"
+        ],
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "error",
+        "react/prop-types": "off"
+    },
+    "env": {
+        "browser": true,
+        "es2021": true
+    }
+}

--- a/frontend/src/entities/configuration/configuration.tsx
+++ b/frontend/src/entities/configuration/configuration.tsx
@@ -47,7 +47,7 @@ export function Configuration () {
     const notificationService = NotificationService(dispatch);
 
     const generateDescription = (service: string) => {
-        return `Sync metadata for all ${service} associated with ${window.env.APPLICATION_NAME}`
+        return `Sync metadata for all ${service} associated with ${window.env.APPLICATION_NAME}`;
     };
 
     const resourceOptions: MultiselectProps.Option[] = [

--- a/frontend/src/shared/model/resource-metadata.model.ts
+++ b/frontend/src/shared/model/resource-metadata.model.ts
@@ -46,7 +46,7 @@ type EMRMetadata = {
     CreationTime: string;
     Name: string;
     NormalizedInstanceHours: number;
-}
+};
 
 type HPOJobMetadata = {
     CreationTime: string;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds `.eslintrc` to frontend directory so that stylistic rules are applied to frontend in addition to the CDK code. Spelling dictionary from root level `.eslintrc` file is already applied to frontend files. Confirmed this addressed the issues by running `act` locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
