### PR TITLE
[AIML-ADC-7208] Fix issue with validation not displaying for Continuous parameters

### DIFF
--- a/frontend/src/entities/jobs/hpo/create/training-definitions/training-job-definition.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/training-job-definition.tsx
@@ -207,6 +207,7 @@ export function TrainingJobDefinition (props: TrainingJobDefinitionProps) {
             }),
             HyperParameterRanges: z.object({
                 IntegerParameterRanges: z.any(),
+                ContinuousParameterRanges: z.any(),
                 CategoricalParameterRanges: z.any(),
             }),
             StaticHyperParameters: z.any(),
@@ -236,8 +237,9 @@ export function TrainingJobDefinition (props: TrainingJobDefinitionProps) {
                             }
                         }
                     });
+                    const parameterRanges = Object.values(item.HyperParameterRanges.ContinuousParameterRanges).concat(Object.values(item.HyperParameterRanges.IntegerParameterRanges));
 
-                    Object.values(item.HyperParameterRanges.IntegerParameterRanges).forEach(
+                    parameterRanges.forEach(
                         (parameterRange: any) => {
                             const hyperParameter = algorithm.defaultHyperParameters.find(
                                 (hyperParameter) => hyperParameter.key === parameterRange.Name


### PR DESCRIPTION
*Issue #, if available:*
AIML-ADC-7208

*Description of changes:*
This fixes an issue where validation messages were not being displayed in the UI for invalid continuous parameter range fields in HPO job.
<img width="966" alt="hpoParameterRanges" src="https://github.com/awslabs/mlspace/assets/3723216/fa065274-eee8-48e7-a681-19ceb6810d48">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
