### PR TITLE
[AIML-ADC-5626] Autodetect batch translate fails in unsupported regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,133 @@
 ## Deployment Prerequisites
 
 ### Software
+
 In order to build and deploy MLSpace to your AWS account you will need the following software installed on your machine:
+
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - [nodejs](https://nodejs.org/en/download/) 18+
 - [docker](https://docker.com) or a compatible runtime for generating lambda layers
 - cdk (`npm install -g cdk`)
 
-
 ### Additional Information
+
 In addition to the required software you will also need to have the following information:
+
 - AWS account Id and region you'll be deploying MLSpace into (you'll need admin credentials or similar)
 - IdP information including the OIDC endpoint and client name
 
-### Configure deployment parameters
-Update the values in `lib/constants.ts` based on your specific deployment needs. Some of these will directly impact whether new resources are created within your account or whether existing resources (VPC, KMS, Roles, etc) will be leveraged.
+## Configuring MLSpace
+
+There are two options for configuring MLSpace for deployment:
+
+### Option 1 (Recommended)- Configure using the MLSpace Config Wizard
+
+Configure MLSpace using Option 1 if:
+
+- you want to be prompted for only the settings necessary to launch MLSpace with minimal configuration changes; or...
+- you want to be prompted only for the necessary settings as well as values that are commonly modified (VPC configuration, IAM roles, etc)
+- you want to configure and deploy MLSpace with a generated config file which is not committed to git
+
+After running the MLSpace Config Wizard, a new file will be generated: `/lib/config.json`.
+
+When MLSpace is deployed it will merge the settings in `/lib/config.json` and `constants.ts` to determine the final configuration settings (giving precedence to values set in `/lib/config.json`).
+
+Any values left empty while using the MLSpace Config Wizard will default to what is set in the `lib/constants.ts` file.
+
+The MLSpace Config Wizard can be invoked with the command:
+
+```Bash
+npm run config
+```
+
+This will prompt you to choose between Basic Config and Advanced Config.
+
+- Basic Config - only prompts for the properties which must be set in order to deploy MLSpace.
+- Advanced Config - prompts for required fields as well as optional configurations which are commonly customized.
+
+If selecting Basic Config, the properties you will be prompted for are:
+
+- AWS account ID: the AWS account ID for the account MLSpace will be deployed into
+- AWS region: the region that MLSpace resources will be deployed into
+- OIDC URL: the OIDC endpoint that will be used for MLSpace authentication
+- OIDC Client Name: the OIDC client name that should be used by MLSpace for authentication
+
+If selecting Advanced Config you will be prompted for the same properties Basic Config prompts for, as well as other optional values. Anything not specified will use the defaults in `constants.ts` and/or provisioned by MLSpace.
+
+The Advanced Config will ask:
+
+**Do you want to use existing VPC?**
+If you answered yes you will be prompted for:
+
+- VPC Name: if MLSpace is being deployed into an existing VPC this should be the name of that VPC
+- VPC ID: if MLSpace is being deployed into an existing VPC this should be the ID of that VPC
+- VPC Default Security Group: if MLSpace is being deployed into an existing VPC this should be the default security group of that VPC
+
+**Do you want to use existing IAM Roles?**
+If you answered yes you will be prompted for:
+
+- S3 Reader Role ARN: ARN of an existing IAM role to use for reading from the static website S3 bucket
+- Bucket Deployment Role ARN: ARN of an existing IAM role to use for deploying to the static website S3 bucket
+- Notebook Role ARN: ARN of an existing IAM role to associate with all notebooks created in MLSpace
+- App Role ARN: ARN of an existing IAM role to use for executing the MLSpace lambdas
+- EMR Default Role ARN: ARN of an existing IAM role that will be used as the 'ServiceRole' for all EMR clusters
+- EMR EC2 Instance Role ARN: ARN of an existing role that will be used as the 'JobFlowRole' and 'AutoScalingRole' for all EMR clusters
+
+**Do you want to modify the banner displayed on MLSpace?**
+If you answered yes you will be prompted for:
+
+- System Banner Text: the text to display on the system banner displayed at the top and bottom of the MLSpace web application. If set to a blank string no banner will be displayed
+- System Banner Background Color: the background color of the system banner if enabled
+- System Banner Text Color: the color of the text displayed in the system banner if enabled
+
+### Option 2 - Configure by updating lib/constants.ts
+
+Configure MLSpace using Option 2 if:
+
+- the MLSpace Config Wizard doesn't configure all of the settings you need to customize
+- you wish to have your configuration changes in a file that's committed to git
+- will have to resolve conflicts when upgrading MLSpace
+
+If you are pre-creating roles you will need to ensure that the required role arns (`APP_ROLE_ARN`, `NOTEBOOK_ROLE_ARN`), role names (`KEY_MANAGER_ROLE_NAME` if `EXISTING_KMS_MASTER_KEY_ARN` is not set), and `AWS_ACCOUNT` (used to ensure unique S3 bucket names) have been properly set in `lib/constants.ts`.
+
+You will also need to set `OIDC_URL` and `OIDC_CLIENT_NAME` with the correct values based on your chosen IdP. These property must be set prior to deploying MLSpace.
+
+To see the full list of configurable properties and their descriptions, see the [Configurable deployment parameters section](Configurable deployment parameters).
+
+### Creating a production optimized web app build
+
+Once configuration has been completed you will also need to create a production build of the web application. You can do this by changing to the web application directory (`frontend/`) and running:
+
+```Bash
+# From project root directory
+cd frontend
+npm run clean && npm install
+```
+
+This will generate a production optimized build of the web application and documentation, the resulting artifacts will be written to the `frontend/build/` directory.
+
+There are no web application specific configuration parameters that need to be set as the configuration will be dynamically generated as part of the CDK deployment based on the variables set during the configuration steps, as well as the deployed resources.
+
+## Deploying the CDK application
+
+The MLSpace application is a standard CDK application and can be deployed just as any CDK application is deployed:
+
+```Bash
+# From project root directory
+npm install && cdk bootstrap <REPLACE WITH YOUR ACCOUNT NUMBER>/<REPLACE WITH TARGET REGION>
+```
+
+Once the account has been bootstrap you can deploy the application. You can optionally include `--require-approval never` in the below command if you don't want to confirm changes:
+
+```Bash
+# From project root directory
+cdk deploy --all
+```
+
+## Configurable deployment parameters
+
+If the config-helper doesn't provide the level of customization you need for your deployment, you can update the values in `lib/constants.ts` based on your specific deployment needs. Some of these will directly impact whether new resources are created within your account or whether existing resources (VPC, KMS, Roles, etc) will be leveraged.
 
 | Variable   |      Description      |  Default |
 |----------|:-------------:|------:|
@@ -58,42 +170,14 @@ Update the values in `lib/constants.ts` based on your specific deployment needs.
 | EXISTING_VPC_ID | If MLSpace is being deployed into an existing VPC this should be the id of that VPC (must also set `EXISTING_VPC_NAME`) | - |
 | EXISTING_VPC_DEFAULT_SECURITY_GROUP | If MLSpace is being deployed into an existing VPC this should be the default security group of that VPC | - |
 | APP_ROLE_ARN | Arn of an existing IAM role to use for executing the MLSpace lambdas. This value must be set to an existing role because the default CDK deployment will not create one. | - |
-| NOTEBOOK_ROLE_ARN | Arn of an existing IAM role to associate with all notebooks created in MLSpace. If using dynamic roles based on project/user combinations the specific combination role will be used instaed. This value must be set to an existing role because the default CDK deployment will not create one. | - |
+| NOTEBOOK_ROLE_ARN | Arn of an existing IAM role to associate with all notebooks created in MLSpace. If using dynamic roles based on project/user combinations the specific combination role will be used instead. This value must be set to an existing role because the default CDK deployment will not create one. | - |
 | S3_READER_ROLE_ARN | Arn of an existing IAM role to use for reading from the static website S3 bucket. If not specified a new role with the correct privileges will be created | - |
 | EMR_DEFAULT_ROLE_ARN | Role that will be used as the "ServiceRole" for all EMR clusters | - |
 | EMR_EC2_INSTANCE_ROLE_ARN | Role that will be used as the "JobFlowRole" and "AutoScalingRole" for all EMR clusters | - |
 | ENABLE_ACCESS_LOGGING | Whether or not to enable access logging for S3 and APIGW in MLSpace | `true` |
-| APIGATEWAY_CLOUDWATCH_ROLE_ARN | If API Gateway access logging is enabled (`ENABLE_ACCESS_LOGGING` is true) then this is the arn of the role that will be used to push those access logs | - |
+| APIGATEWAY_CLOUDWATCH_ROLE_ARN | If API Gateway access logging is enabled (`ENABLE_ACCESS_LOGGING` is true) then this is the ARN of the role that will be used to push those access logs | - |
 | CREATE_MLSPACE_CLOUDTRAIL_TRAIL | Whether or not to create an MLSpace trail within the account | `true` |
 | NEW_USERS_SUSPENDED | Whether or not new user accounts will be created in a suspended state by default | `false` |
 | ENABLE_TRANSLATE | Whether or not translate capabilities will be deployed/enabled in MLSpace. If translate is not available in the region you are deploying to you should set this to `false` | `true` |
 | LAMBDA_RUNTIME | The lambda runtime to use for MLSpace lambda functions and layers. This needs to be a python runtime available in the region in which MLSpace is being deployed. | Python 3.11 |
 | LAMBDA_ARCHITECTURE | The architecture on which to deploy the MLSpace lambda functions. All lambda layers will also need to be built for the selected archiecture. You can do this by ensuring you run the `cdk deploy` command from a machine with the same architecture you're targeting. | x86 |
-
-
-### Creating a production optimized web app build
-In addition to updating the necessary parameters in the CDK constants file you will also need to create a production build of the web application. You can do this by changing to the web application directory (`frontend/`) and running:
-```
-# From project root directory
-cd frontend
-npm run clean && npm install
-```
-This will generate a production optimized build of the web application and documentation, the resulting artifacts will be written to the `frontend/build/` directory.
-
-There are no web application specific configuration parameters that need to be set as the configuration will be dynamically generated as part of the CDK deployment based on the variables set in `constants.ts` and well as the deployed resources.
-
-## Deploying the CDK application
-If you are pre-creating roles you will need to ensure that the required role arns (`APP_ROLE_ARN`, `NOTEBOOK_ROLE_ARN`), role names (`KEY_MANAGER_ROLE_NAME` if `EXISTING_KMS_MASTER_KEY_ARN` is not set), and `AWS_ACCOUNT` (used to ensure unique S3 bucket names) have been properly set in `lib/constants.ts`.
-
-You will also need to set `OIDC_URL` and `OIDC_CLIENT_NAME` with the correct values based on your chosen IdP. These property must be set prior to deploying MLSpace.
-
-The MLSpace application is a standard CDK application and can be deployed just as any CDK application is deployed:
-```
-# From project root directory
-npm install && cdk bootstrap <REPLACE WITH YOUR ACCOUNT NUMBER>/<REPLACE WITH TARGET REGION>
-```
-Once the account has been bootstrap you can deploy the application. You can optionally include `--require-approval never` in the below command if you don't want to confirm changes:
-```
-# From project root directory
-cdk deploy --all
-```

--- a/bin/mlspace-cdk.ts
+++ b/bin/mlspace-cdk.ts
@@ -19,27 +19,6 @@
 import { App, Aspects, Tags } from 'aws-cdk-lib';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import 'source-map-support/register';
-import {
-    ACCESS_LOGS_BUCKET_NAME,
-    AWS_ACCOUNT,
-    AWS_REGION,
-    CONFIG_BUCKET_NAME,
-    DATA_BUCKET_NAME,
-    ENABLE_TRANSLATE,
-    EXISTING_KMS_MASTER_KEY_ARN,
-    KEY_MANAGER_ROLE_NAME,
-    LOGS_BUCKET_NAME,
-    NOTEBOOK_PARAMETERS_FILE_NAME,
-    NOTIFICATION_DISTRO,
-    OIDC_CLIENT_NAME,
-    OIDC_URL,
-    OIDC_VERIFY_SIGNATURE,
-    SYSTEM_BANNER_BACKGROUND_COLOR,
-    SYSTEM_BANNER_TEXT,
-    SYSTEM_BANNER_TEXT_COLOR,
-    SYSTEM_TAG,
-    WEBSITE_BUCKET_NAME
-} from '../lib/constants';
 import { AdminApiStack } from '../lib/stacks/api/admin';
 import { DatasetsApiStack } from '../lib/stacks/api/datasets';
 import { EmrApiStack } from '../lib/stacks/api/emr';
@@ -56,30 +35,19 @@ import { KMSStack } from '../lib/stacks/kms';
 import { VPCStack } from '../lib/stacks/vpc';
 import { ADCLambdaCABundleAspect } from '../lib/utils/adcCertBundleAspect';
 import { ApiDeploymentStack } from '../lib/stacks/api/apiDeployment';
+import { MLSpaceConfig, generateConfig } from '../lib/utils/configTypes';
 
-const validateRequiredProperty = (val: string, name: string) => {
-    if (!val) {
-        throw new Error(`${name} is a required property. \nPlease set the value in 'lib/constants.ts'.`);
-    }
-};
 
-validateRequiredProperty(AWS_ACCOUNT, 'AWS_ACCOUNT');
-validateRequiredProperty(OIDC_URL, 'OIDC_URL');
-validateRequiredProperty(OIDC_CLIENT_NAME, 'OIDC_CLIENT_NAME');
-validateRequiredProperty(AWS_REGION, 'AWS_REGION');
-
-if (!EXISTING_KMS_MASTER_KEY_ARN) {
-    validateRequiredProperty(KEY_MANAGER_ROLE_NAME, 'KEY_MANAGER_ROLE_NAME');
-}
+const config: MLSpaceConfig = generateConfig();
 
 const envProperties = {
-    account: AWS_ACCOUNT,
-    region: AWS_REGION
+    account: config.AWS_ACCOUNT,
+    region: config.AWS_REGION
 };
 
 const app = new App();
 const stacks = [];
-const isIso = ['us-iso-east-1', 'us-isob-east-1'].includes(AWS_REGION);
+const isIso = ['us-iso-east-1', 'us-isob-east-1'].includes(config.AWS_REGION);
 
 const vpcStack = new VPCStack(app, 'mlspace-vpc', {
     env: envProperties,
@@ -90,31 +58,34 @@ const vpcStack = new VPCStack(app, 'mlspace-vpc', {
     deployS3Endpoint: true,
     deploySTSEndpoint: true,
     isIso,
+    mlspaceConfig: config
 });
 const mlSpaceVPC = vpcStack.vpc;
 
 const kmsStack = new KMSStack(app, 'mlspace-kms', {
     env: envProperties,
-    keyManagerRoleName: KEY_MANAGER_ROLE_NAME
+    keyManagerRoleName: config.KEY_MANAGER_ROLE_NAME,
+    mlspaceConfig: config
 });
 stacks.push(kmsStack);
 
-const configBucketName = `${CONFIG_BUCKET_NAME}-${AWS_ACCOUNT}`;
-const dataBucketName = `${DATA_BUCKET_NAME}-${AWS_ACCOUNT}`;
-const websiteBucketName = `${WEBSITE_BUCKET_NAME}-${AWS_ACCOUNT}`;
-const cwlBucketName = `${LOGS_BUCKET_NAME}-${AWS_ACCOUNT}`;
-const accessLogsBucketName = `${ACCESS_LOGS_BUCKET_NAME}-${AWS_ACCOUNT}`;
+const configBucketName = `${config.CONFIG_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
+const dataBucketName = `${config.DATA_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
+const websiteBucketName = `${config.WEBSITE_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
+const cwlBucketName = `${config.LOGS_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
+const accessLogsBucketName = `${config.ACCESS_LOGS_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
 
 const iamStack = new IAMStack(app, 'mlspace-iam', {
     env: envProperties,
     dataBucketName,
     configBucketName,
     websiteBucketName,
-    enableTranslate: ENABLE_TRANSLATE,
+    enableTranslate: config.ENABLE_TRANSLATE,
     encryptionKey: kmsStack.masterKey,
     mlSpaceVPC: vpcStack.vpc,
     mlSpaceDefaultSecurityGroupId: vpcStack.vpcSecurityGroupId,
-    isIso
+    isIso,
+    mlspaceConfig: config
 });
 iamStack.addDependency(vpcStack);
 iamStack.addDependency(kmsStack);
@@ -135,7 +106,7 @@ const coreStack = new CoreStack(app, 'mlspace-core', {
     websiteBucketName,
     cwlBucketName,
     accessLogsBucketName,
-    notificationDistro: NOTIFICATION_DISTRO,
+    notificationDistro: config.NOTIFICATION_DISTRO,
     encryptionKey: kmsStack.masterKey,
     mlSpaceAppRole,
     mlSpaceNotebookRole,
@@ -144,6 +115,7 @@ const coreStack = new CoreStack(app, 'mlspace-core', {
     mlSpaceDefaultSecurityGroupId: vpcStack.vpcSecurityGroupId,
     lambdaSourcePath,
     isIso,
+    mlspaceConfig: config
 });
 coreStack.addDependency(kmsStack);
 coreStack.addDependency(vpcStack);
@@ -152,6 +124,7 @@ stacks.push(coreStack);
 stacks.push(new SagemakerStack(app, 'mlspace-sagemaker', {
     env: envProperties,
     dataBucketName,
+    mlspaceConfig: config
 }));
 
 const restStack = new RestApiStack(app, 'mlspace-web-tier', {
@@ -162,16 +135,17 @@ const restStack = new RestApiStack(app, 'mlspace-web-tier', {
     mlSpaceAppRole,
     lambdaSourcePath,
     frontEndAssetsPath,
-    verifyOIDCTokenSignature: OIDC_VERIFY_SIGNATURE,
+    verifyOIDCTokenSignature: config.OIDC_VERIFY_SIGNATURE,
     mlSpaceVPC,
     lambdaSecurityGroups: [vpcStack.vpcSecurityGroup],
     isIso,
-    enableTranslate: ENABLE_TRANSLATE,
+    enableTranslate: config.ENABLE_TRANSLATE,
     systemBannerConfiguration: {
-        text: SYSTEM_BANNER_TEXT,
-        backgroundColor: SYSTEM_BANNER_BACKGROUND_COLOR,
-        fontColor: SYSTEM_BANNER_TEXT_COLOR
-    }
+        text: config.SYSTEM_BANNER_TEXT,
+        backgroundColor: config.SYSTEM_BANNER_BACKGROUND_COLOR,
+        fontColor: config.SYSTEM_BANNER_TEXT_COLOR
+    },
+    mlspaceConfig: config
 });
 
 // The REST stack will push a config file to the website bucket so the Core
@@ -189,7 +163,7 @@ const apiStackProperties: ApiStackProperties = {
     cwlBucketName,
     applicationRole: mlSpaceAppRole,
     notebookInstanceRole: mlSpaceNotebookRole,
-    notebookParamFileKey: NOTEBOOK_PARAMETERS_FILE_NAME,
+    notebookParamFileKey: config.NOTEBOOK_PARAMETERS_FILE_NAME,
     deploymentEnvironmentName: 'mlspace',
     authorizer: restStack.mlspaceRequestAuthorizer,
     lambdaSourcePath,
@@ -198,6 +172,7 @@ const apiStackProperties: ApiStackProperties = {
     permissionsBoundaryArn: iamStack.mlSpacePermissionsBoundary?.managedPolicyArn,
     emrServiceRoleName: iamStack.emrServiceRoleName,
     emrEC2RoleName: iamStack.emrEC2RoleName,
+    mlspaceConfig: config
 };
 
 const apiStacks = [
@@ -210,7 +185,7 @@ const apiStacks = [
     new EmrApiStack(app, 'mlspace-emr-apis', apiStackProperties),
 ];
 
-if (ENABLE_TRANSLATE) {
+if (config.ENABLE_TRANSLATE) {
     apiStacks.push(new TranslateApiStack(app, 'mlspace-translate-apis', apiStackProperties));
 }
 const apiDeploymentStack = new ApiDeploymentStack(app, 'mlspace-api-deployment', {
@@ -234,7 +209,7 @@ stacks.push(...apiStacks);
 stacks.forEach((resource) => {
     // Tags are not supported on log groups in ADC regions
     if (!isIso || resource instanceof LogGroup) {
-        Tags.of(resource).add('system', SYSTEM_TAG);
+        Tags.of(resource).add('system', config.SYSTEM_TAG);
         Tags.of(resource).add('user', 'MLSpaceApplication');
         Tags.of(resource).add('project', 'MLSpaceInfrastructure');
     }

--- a/bin/scripts/config-helper.js
+++ b/bin/scripts/config-helper.js
@@ -1,0 +1,211 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+const fs = require('fs');
+const figlet = require("figlet");
+const { prompt } = require('enquirer');
+
+const BASIC = 'basic';
+const ADVANCED = 'advanced';
+
+// Stores all user answers
+let answers = {}
+
+console.log(figlet.textSync("MLSpace Config Wizard"));
+
+createConfig();
+
+
+
+
+async function createConfig() {
+    const configTypeResponse = await prompt({
+        type: "select",
+        name: "configType",
+        choices: [
+            { message: "Basic Config - only prompts for the properties which must be set in order to deploy MLSpace.", name: BASIC },
+            { message: "Advanced Config - prompts for required fields as well as optional configurations which are commonly customized.", name: ADVANCED },
+        ],
+        message: "Select a configuration type:",
+    })
+
+    await basicConfigPrompts();
+
+    if(configTypeResponse.configType === ADVANCED) {
+        await advancedConfigPrompts();
+    }
+    
+    fs.writeFileSync('./lib/config.json', JSON.stringify(answers, undefined, 4));
+}
+
+
+async function advancedConfigPrompts() {
+    const vpcResponse = await prompt({
+        type: "confirm",
+        name: "existingVpc",
+        message: "Do you want to use existing VPC? (selecting no will create a new VPC for MLSpace)",
+    })
+    if(vpcResponse.existingVpc) {
+        await askVpcQuestions();
+    }
+
+    const roleResponse = await prompt({
+        type: "confirm",
+        name: "existingRoles",
+        message: "Do you want to use existing IAM Roles? (selecting no will create new IAM Roles for MLSpace actions)",
+    });
+    if(roleResponse.existingRoles) {
+        await askRoleQuestions();
+    }
+
+    const bannerResponse = await prompt({
+        type: "confirm",
+        name: "createBanner",
+        message: "Do you want to modify the banner displayed on MLSpace? (selecting no will default in MLSpace having no banner)",
+    })
+    if(bannerResponse.createBanner) {
+        await askBannerQuestions();
+    }
+
+    // List of other advanced settings which don't fit into a category
+    const otherAdvancedSettings = [
+        {
+            type: "confirm",
+            name: "NEW_USERS_SUSPENDED",
+            message: "New Users Suspended: whether or not new user accounts will be created in a suspended state by default",
+        },
+    ]
+
+    const otherPromptAnswers = await prompt(otherAdvancedSettings);
+    answers = {...answers, ...otherPromptAnswers};
+
+}
+
+// These properties must always be set
+async function basicConfigPrompts() {
+    let basicQuestions = [
+        {
+        type: "input",
+        name: "AWS_ACCOUNT",
+        message: "AWS Account: the AWS account ID for the account MLSpace will be deployed into",
+        },
+        {
+        type: "input",
+        name: "AWS_REGION",
+        message: "AWS Region: the region that MLSpace resources will be deployed into",
+        },
+        {
+            type: "input",
+            name: "OIDC_URL",
+            message: "OIDC URL: the OIDC endpoint that will be used for MLSpace authentication",
+        },
+        {
+            type: "input",
+            name: "OIDC_CLIENT_NAME",
+            message: "OIDC Client Name: the OIDC client name that should be used by MLSpace for authentication",
+        },
+        {
+            type: "input",
+            name: "KEY_MANAGER_ROLE_NAME",
+            message: "Key Manager Role Name: name of the IAM role with permissions to manage the KMS Key. This could be something like Admin or a dedicated role for KMS Key Management"
+        }
+    ]
+
+    const basicPromptAnswers = await prompt(basicQuestions);
+    answers = {...answers, ...basicPromptAnswers};
+
+}
+
+async function askVpcQuestions() {
+    const vpcQuestions = [
+        {
+            type: "input",
+            name: "EXISTING_VPC_NAME",
+            message: "VPC Name: the name of the VPC into which MLSpace will be deployed",
+        },
+        {
+            type: "input",
+            name: "EXISTING_VPC_ID",
+            message: "VPC ID: the ID of the VPC into which MLSpace will be deployed",
+        },
+        {
+            type: "input",
+            name: "EXISTING_VPC_DEFAULT_SECURITY_GROUP",
+            message: "the ID of the default security group of the VPC into which MLSpace will be deployed",
+        },
+    ]
+
+    const vpcPromptAnswers = await prompt(vpcQuestions);
+    answers = {...answers, ...vpcPromptAnswers};
+}
+
+async function askRoleQuestions() {
+    const roleQuestions = [
+        {
+            type: "input",
+            name: "S3_READER_ROLE_ARN",
+            message: "S3 Reader Role ARN: arn of an existing IAM role to use for reading from the static website S3 bucket. If not specified a new role with the correct privileges will be created",
+        },
+        {
+            type: "input",
+            name: "BUCKET_DEPLOYMENT_ROLE_ARN",
+            message: "Bucket Deployment Role ARN: arn of an existing IAM role to use for deploying to the static website S3 bucket. If not specified a new role with the correct privileges will be created",
+        },
+        {
+            type: "input",
+            name: "NOTEBOOK_ROLE_ARN",
+            message: "Notebook Role ARN: arn of an existing IAM role to associate with all notebooks created in MLSpace. If using dynamic roles based on project/user combinations the specific combination role will be used instead. This value must be set to an existing role because the default CDK deployment will not create one.",
+        },
+        {
+            type: "input",
+            name: "APP_ROLE_ARN",
+            message: "App Role ARN: arn of an existing IAM role to use for executing the MLSpace lambdas. This value must be set to an existing role because the default CDK deployment will not create one",
+        },
+        {
+            type: "input",
+            name: "EMR_DEFAULT_ROLE_ARN",
+            message: "EMR Default Role ARN: arn of an existing IAM role that will be used as the 'ServiceRole' for all EMR clusters",
+        },
+        {
+            type: "input",
+            name: "EMR_EC2_INSTANCE_ROLE_ARN",
+            message: "EMR EC2 Instance Role ARN: arn of an existing role that will be used as the 'JobFlowRole' and 'AutoScalingRole' for all EMR clusters",
+        },
+    ]
+    const rolePromptAnswers = await prompt(roleQuestions);
+    answers = {...answers, ...rolePromptAnswers};
+}
+
+async function askBannerQuestions() {
+    const bannerQuestions = [
+        {
+            type: "input",
+            name: "SYSTEM_BANNER_TEXT",
+            message: "System Banner Text: the text to display on the system banner displayed at the top and bottom of the MLSpace web application. If set to a blank string no banner will be displayed",
+        },
+        {
+            type: "input",
+            name: "SYSTEM_BANNER_BACKGROUND_COLOR",
+            message: "System Banner Background Color: the background color of the system banner if enabled. Supports valid CSS colors including predefined color names, hex values, and rgb values",
+        },
+        {
+            type: "input",
+            name: "SYSTEM_BANNER_TEXT_COLOR",
+            message: "System Banner Text Color: the color of the text displayed in the system banner if enabled. Supports valid CSS colors including predefined color names, hex values, and rgb values",
+        },
+    ]
+    const bannerPromptAnswers = await prompt(bannerQuestions);
+    answers = {...answers, ...bannerPromptAnswers};
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -18,6 +18,9 @@ public/docs
 public/env.js
 public/git-info.js
 
+# config
+lib/config.json
+
 # docs
 docs/.vitepress/dist
 docs/.vitepress/cache

--- a/frontend/docs/admin-guide/getting-started.md
+++ b/frontend/docs/admin-guide/getting-started.md
@@ -114,7 +114,7 @@ The projects table contains project level metadata such as project name, descrip
 | createdAt | Number | Timestamp of when the project was created in {{ $params.APPLICATION_NAME }}.|
 
 #### Project Users Table
-The projects users table serves as a mapping table between projects and users. Additionally it contains the permissions which a particular user has on the corresponding project and assuming dynamic roles are enabled the role arn of the unique project user role. The partition key is `project` and the sort key is `user`. There is a Keys Only projection global secondary index (GSI) for reverse lookup with a partition key of `user` and a sort key of `project`.
+The projects users table serves as a mapping table between projects and users. Additionally it contains the permissions which a particular user has on the corresponding project and assuming dynamic roles are enabled the role ARN of the unique project user role. The partition key is `project` and the sort key is `user`. There is a Keys Only projection global secondary index (GSI) for reverse lookup with a partition key of `user` and a sort key of `project`.
 
 |Attribute|Type|Description|
 |--|--|--|

--- a/frontend/docs/admin-guide/install.md
+++ b/frontend/docs/admin-guide/install.md
@@ -7,7 +7,9 @@ outline: deep
 ## Deployment Prerequisites
 
 ### Software
+
 In order to build and deploy {{ $params.APPLICATION_NAME }} to your AWS account you will need the following software installed on your machine:
+
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - [nodejs](https://nodejs.org/en/download/)
@@ -15,7 +17,9 @@ In order to build and deploy {{ $params.APPLICATION_NAME }} to your AWS account 
 
 
 ### Information
+
 In addition to the required software you will also need to have the following information:
+
 - AWS account Id and region you'll be deploying {{ $params.APPLICATION_NAME }} into (you'll need admin credentials or similar)
 - IdP information including the OIDC endpoint and client name
 
@@ -33,23 +37,27 @@ exisiting roles. If you need to create these roles outside of the CDK deployment
 be configured as follows:
 
 #### Service Role
+
 1. Login to your AWS account and go to the Roles section of the IAM Service in the AWS Console.
 2. Click the "Create role" button and then click the "AWS service" card under "Trusted entity type".
 3. Select the "EMR" service from the dropdown and select the radio button for "EMR" under use case.
 4. Click the next button to advance to the policy screen, the necessary policy will already be attached. Click next to continue.
 5. You can name the role whatever you'd like. Optionally add a description and tags and then click "Create role"
-6. Once the role has been created record the role arn as we'll need to use it later.
+6. Once the role has been created record the role ARN as we'll need to use it later.
 
 #### Instance Role
+
 1. Login to your AWS account and go to the Roles section of the IAM Service in the AWS Console.
 2. Click the "Create role" button and then click the "AWS service" card under "Trusted entity type".
 3. Select the "EMR" service from the dropdown and select the radio button for "EMR Role for EC2" under use case.
 4. Click the next button to advance to the policy screen, the necessary policy will already be attached. Click next to continue.
 5. You can name the role whatever you'd like. Optionally add a description and tags and then click "Create role"
-6. Once the role has been created record the role arn as we'll need to use it later.
+6. Once the role has been created record the role ARN as we'll need to use it later.
 
 #### Cleanup Role
+
 _The cleanup role needs to exist but we do not need the ARN_
+
 1. Login to your AWS account and go to the Roles section of the IAM Service in the AWS Console.
 2. Click the "Create role" button and then click the "AWS service" card under "Trusted entity type".
 3. Select the "EMR" service from the dropdown and select the radio button for "EMR - Cleanup" under use case.
@@ -57,6 +65,7 @@ _The cleanup role needs to exist but we do not need the ARN_
 5. The role has a default name that you cannot change, you can update the description if you want and then click "Create role"
 
 ### Application Roles
+
 We generally expect customers to use their own roles for the {{ $params.APPLICATION_NAME }} APIGW and lambda execution role as well as for the default notebook role.
 While customers may scope these roles down based on the guidelines of their own organization, the following can be used to quickly stand up
 an instance of {{ $params.APPLICATION_NAME }} for demo purposes only. As written these roles and policies should not be used for production usecases.
@@ -75,15 +84,18 @@ or make any additional changes required for your environment.
 |`{MLSPACE_PRIVATE_SUBNET_2}`| The subnet id of one of the {{ $params.APPLICATION_NAME }} VPC private subnets. | `subnet-0a11b2c3333dd44e5` |
 |`{MLSPACE_PRIVATE_SUBNET_3}`| The subnet id of one of the {{ $params.APPLICATION_NAME }} VPC private subnets. | `subnet-0a11b2c3333dd44e5` |
 |`{MLSPACE_VPC_SECURITY_GROUP}`| The id of the default security group for the {{ $params.APPLICATION_NAME }} VPC. | `sg-903004f8` |
-|`{EMR_DEFAULT_ROLE_ARN}` | The arn of the role that will be used as the "ServiceRole" for all EMR Clusters created via {{ $params.APPLICATION_NAME }} | `arn:aws:iam::123456789012:role/EMR_DefaultRole`|
-|`{EMR_EC2_INSTANCE_ROLE_ARN}` | The arn of the role that will be used as the "JobFlowRole" and "AutoScalingRole" for all EMR Clusters created via {{ $params.APPLICATION_NAME }} | `arn:aws:iam::123456789012:role/EMR_EC2_DefaultRole`|
+|`{EMR_DEFAULT_ROLE_ARN}` | The ARN of the role that will be used as the "ServiceRole" for all EMR Clusters created via {{ $params.APPLICATION_NAME }} | `arn:aws:iam::123456789012:role/EMR_DefaultRole`|
+|`{EMR_EC2_INSTANCE_ROLE_ARN}` | The ARN of the role that will be used as the "JobFlowRole" and "AutoScalingRole" for all EMR Clusters created via {{ $params.APPLICATION_NAME }} | `arn:aws:iam::123456789012:role/EMR_EC2_DefaultRole`|
 | `{MLSPACE_APP_ROLE_NAME}` | The name of the {{ $params.APPLICATION_NAME }} application role | `mlspace-app-role` |
 
 #### Notebook Role
+
 In order to create the default {{ $params.APPLICATION_NAME }} notebook policy and role do the following:
+
 1. Login to your AWS account and go to the Policies section of the IAM Service in the AWS Console
 2. Create a new policy with using the JSON editor and paste the following in the text area (after replacing the placeholder variables):
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -321,12 +333,14 @@ In order to create the default {{ $params.APPLICATION_NAME }} notebook policy an
     ]
 }
 ```
+
 3. Click next and optionally add tags to this policy
 4. Click next again and enter a name for this policy. You can name the policy whatever you'd like but ensure you remember it as you'll need it when creating the role.
 5. After the policy has been created you are now ready to create the role. From the IAM Service page click "Roles" on the left hand side.
 6. Click the "Create role" button and then click the "Custom trust policy" card under "Trusted entity type".
 7. Copy and paste the following content into the "Custom trust policy" text area:
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -340,19 +354,23 @@ In order to create the default {{ $params.APPLICATION_NAME }} notebook policy an
     ]
 }
 ```
+
 8. Click the next button and then select the checkbox next to the name of the policy you created in step 4 above.
 9. After selecting the checkbox for the policy click next and enter a name for the role. You can name the role whatever you'd like. Optionally add a description and tags and then click "Create role"
-10. Once the role has been created record the role arn as we'll need to use it later.
+10. Once the role has been created record the role ARN as we'll need to use it later.
 
 #### App Role
+
 In order to create the default {{ $params.APPLICATION_NAME }} Application policy and role do the following:
+
 1. Login to your AWS account and go to the Policies section of the IAM Service in the AWS Console
 2. Create a new managed policy which will be used as a permissions boundary for dynamically created
 project users roles. This policy assumes you're using the default value for the S3 data and config
 bucket names (`mlspace-data-{AWS_ACCOUNT}` and `mlspace-config-{AWS_ACCOUNT}`).
 If you're using a custom data bucket name you'll need to update the resource values within the policy.
 Using the JSON editor paste the following in the text area (after replacing the placeholder variables):
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -642,6 +660,7 @@ Using the JSON editor paste the following in the text area (after replacing the 
     ]
 }
 ```
+
 3. Click next and optionally add tags to this policy.
 4. Click next again and enter a name for this policy. You can name the policy whatever you'd like
 but ensure you remember it as you'll need it when creating the role. The example below assumes you've
@@ -650,7 +669,8 @@ you'll need to update the `"iam:PermissionsBoundary` condition in the `iam:Creat
 5. After the permission boundary policy has been created you are now ready to create the application
 policy. From the IAM Service page click "Policies" on the left hand side.
 6. Create a new policy with using the JSON editor and paste the following in the text area (after replacing the placeholder variables):
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -922,12 +942,14 @@ policy. From the IAM Service page click "Policies" on the left hand side.
     ]
 }
 ```
+
 7. Click next and optionally add tags to this policy
 8. Click next again and enter a name for this policy. You can name the policy whatever you'd like but ensure you remember it as you'll need it when creating the role.
 9. After the policy has been created you are now ready to create the role. From the IAM Service page click "Roles" on the left hand side.
 10. Click the "Create role" button and then click the "Custom trust policy" card under "Trusted entity type".
 11. Copy and paste the following content into the "Custom trust policy" text area:
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -941,15 +963,19 @@ policy. From the IAM Service page click "Policies" on the left hand side.
     ]
 }
 ```
+
 12. Click the next button and then select the checkbox next to the name of the policy you created in step 8 above. You will also need to attach the default notebook policy you previously created as well as the AWS managed policy `AWSLambdaVPCAccessExecutionRole`. In total you should have 3 policies attached to the role.
 13. After selecting the 3 policies click next and enter a name for the role. You can name the role whatever you'd like. Optionally add a description and tags and then click "Create role"
-14. Once the role has been created record the role arn as we'll need to use it later.
+14. Once the role has been created record the role ARN as we'll need to use it later.
 
 #### S3 Reader Role
+
 The {{ $params.APPLICATION_NAME }} react app is hosted statically in S3 and accessed via an API Gateway S3 proxy integration. This proxy resource will use the role associated with the `S3_READER_ROLE_ARN` in `constants.ts` if specified. If you do not specify an ARN {{ $params.APPLICATION_NAME }} will attempt to create a new role.  You can manually create the necessary policy and role using the following steps:
+
 1. Login to your AWS account and go to the Policies section of the IAM Service in the AWS Console
 2. Create a new policy using the JSON editor and paste the following in the text area (after replacing the placeholder variables):
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [{
@@ -959,12 +985,14 @@ The {{ $params.APPLICATION_NAME }} react app is hosted statically in S3 and acce
     }]
 }
 ```
+
 3. Click next and optionally add tags to this policy.
 4. Click next again and enter a name for this policy. You can name the policy whatever you'd like but ensure you remember it as you'll need it when creating the role.
 5. After the policy has been created you are now ready to create the role. From the IAM Service page click "Roles" on the left hand side.
 6. Click the "Create role" button and then click the "Custom trust policy" card under "Trusted entity type".
 7. Copy and paste the following content into the "Custom trust policy" text area:
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -978,16 +1006,20 @@ The {{ $params.APPLICATION_NAME }} react app is hosted statically in S3 and acce
     ]
 }
 ```
+
 8. Click the next button and then select the checkbox next to the name of the policy you created in step 4 above.
 9. After selecting the policy click next and enter a name for the role. You can name the role whatever you'd like. Optionally add a description and tags and then click "Create role"
-10. Once the role has been created record the role arn as you'll need to update `constants.ts` to use it.
+10. Once the role has been created record the role ARN as you'll need to update `constants.ts` to use it.
 
 #### API Gateway CloudWatch Role
+
 When `ENABLE_ACCESS_LOGGING` is set to `true` [API Gateway uses a single role account-wide](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions) for interacting with CloudWatch. If you would like to provide that role to {{ $params.APPLICATION_NAME }} you can set the `APIGATEWAY_CLOUDWATCH_ROLE_ARN` property in `constants.ts` otherwise the role will be automatically created during deployment. In order to create the API Gateway CloudWatch role manually you can take the following steps:
+
 1. Login to your AWS account and go to the Roles section of the IAM Service in the AWS Console.
 2. Click the "Create role" button and then click the "Custom trust policy" card under "Trusted entity type".
 3. Copy and paste the following content into the "Custom trust policy" text area:
-```
+
+```JSON
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -1001,12 +1033,14 @@ When `ENABLE_ACCESS_LOGGING` is set to `true` [API Gateway uses a single role ac
     ]
 }
 ```
+
 4. Click the next button and then select the checkbox next to the AWS managed policy `AmazonAPIGatewayPushToCloudWatchLogs`.
 5. After selecting the managed policy click next and enter a name for the role. You can name the role whatever you'd like. Optionally add a description and tags and then click "Create role"
-6. Once the role has been created record the role arn and update the `APIGATEWAY_CLOUDWATCH_ROLE_ARN` property in `constants.ts` to use the arn of the newly created role.
+6. Once the role has been created record the role ARN and update the `APIGATEWAY_CLOUDWATCH_ROLE_ARN` property in `constants.ts` to use the ARN of the newly created role.
 
 ### Deployment Parameters
-Update the values in `lib/constants.ts` based on your specific deployment needs. Some of these will directly impact whether new resources are created within your account or whether existing resources (VPC, KMS, Roles, etc) will be leveraged.
+
+Use the MLSpace Config Wizard by running `npm run config` and select "Advanced Configuration" for an interactive prompt which will set configuration values on your behalf in a generated `/lib/config.json` file. Alternatively, update the values in `/lib/constants.ts` based on your specific deployment needs. Some of these will directly impact whether new resources are created within your account or whether existing resources (VPC, KMS, Roles, etc) will be leveraged.
 
 | Variable   |      Description      |  Default |
 |----------|:-------------|------:|
@@ -1044,12 +1078,12 @@ Update the values in `lib/constants.ts` based on your specific deployment needs.
 | `EXISTING_VPC_ID` | If {{ $params.APPLICATION_NAME }} is being deployed into an existing VPC this should be the id of that VPC (must also set `EXISTING_VPC_NAME`) | - |
 | `EXISTING_VPC_DEFAULT_SECURITY_GROUP` | If {{ $params.APPLICATION_NAME }} is being deployed into an existing VPC this should be the default security group of that VPC | - |
 | `APP_ROLE_ARN` | Arn of an existing IAM role to use for executing the {{ $params.APPLICATION_NAME }} lambdas. This value must be set to an existing role because the default CDK deployment will not create one. | - |
-| `NOTEBOOK_ROLE_ARN` | Arn of an existing IAM role to associate with all notebooks created in {{ $params.APPLICATION_NAME }}. If using dynamic roles based on  project/user combinations the specific combination role will be used instaed. This value must be set to an existing role because the default CDK deployment will not create one. | - |
+| `NOTEBOOK_ROLE_ARN` | Arn of an existing IAM role to associate with all notebooks created in {{ $params.APPLICATION_NAME }}. If using dynamic roles based on  project/user combinations the specific combination role will be used instead. This value must be set to an existing role because the default CDK deployment will not create one. | - |
 | `S3_READER_ROLE_ARN` | Arn of an existing IAM role to use for reading from the static website S3 bucket. If not specified a new role with the correct privileges will be created | - |
 | `EMR_DEFAULT_ROLE_ARN` | Role that will be used as the "ServiceRole" for all EMR clusters | - |
 | `EMR_EC2_INSTANCE_ROLE_ARN` | Role that will be used as the "JobFlowRole" and "AutoScalingRole" for all EMR clusters | - |
 | `ENABLE_ACCESS_LOGGING` | Whether or not to enable access logging for S3 and APIGW in {{ $params.APPLICATION_NAME }} | `true` |
-| `APIGATEWAY_CLOUDWATCH_ROLE_ARN` | If API Gateway access logging is enabled (`ENABLE_ACCESS_LOGGING` is true) then this is the arn of the role that will be used to push those access logs | - |
+| `APIGATEWAY_CLOUDWATCH_ROLE_ARN` | If API Gateway access logging is enabled (`ENABLE_ACCESS_LOGGING` is true) then this is the ARN of the role that will be used to push those access logs | - |
 | `CREATE_MLSPACE_CLOUDTRAIL_TRAIL` | Whether or not to create an {{ $params.APPLICATION_NAME }} trail within the account | `true` |
 | `NEW_USERS_SUSPENDED` | Whether or not new user accounts will be created in a suspended state by default | `true` |
 | `ENABLE_TRANSLATE` | Whether or not translate capabilities will be deployed/enabled in {{ $params.APPLICATION_NAME }}. If translate is not available in the region you are deploying to you should set this to `false` | `true` |
@@ -1057,22 +1091,29 @@ Update the values in `lib/constants.ts` based on your specific deployment needs.
 | `LAMBDA_ARCHITECTURE` | The architecture on which to deploy the {{ $params.APPLICATION_NAME }} lambda functions. All lambda layers will also need to be built for the selected archiecture. You can do this by ensuring you run the `cdk deploy` command from a machine with the same architecture you're targeting. | x86 |
 
 ### Production Web App
+
 In addition to updating the necessary parameters in the CDK constants file you will also need to create a production build of the web application. You can do this by changing to the web application directory (`MLSpace/frontend/`) and running:
-```
+
+```Bash
 npm run clean && npm install
 ```
+
 This will generate a production optimized build of the web application and place the required artifacts in the `build/` directory.
 
 There are no web application specific configuration parameters that need to be set as the configuration will be dynamically generated as part of the CDK deployment based on the variables set there.
 
 ## Deploying the CDK application
+
 Enusre that the required role arns (`APP_ROLE_ARN`, `NOTEBOOK_ROLE_ARN`), role names (`KEY_MANAGER_ROLE_NAME` if `EXISTING_KMS_MASTER_KEY_ARN` is not set), and `AWS_ACCOUNT` (used to ensure unique S3 bucket names) have been properly set in `lib/constants.ts`.
 
 The {{ $params.APPLICATION_NAME }} application is a standard CDK application and can be deployed just as any CDK application is deployed. From the `MLSpace/deployment/` directory you can run the following:
-```
+
+```Bash
 npm install && cdk bootstrap <REPLACE WITH YOUR ACCOUNT NUMBER>/<REPLACE WITH TARGET REGION>
 ```
+
 Once the account has been bootstrap you can deploy the application. (Optionally include `--require-approval never` in the below command if you don't want to confirm changes):
-```
+
+```Bash
 cdk deploy --all
 ```

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -117,7 +117,7 @@ export const OIDC_CLIENT_NAME = '';
 export const OIDC_VERIFY_SSL = true;
 export const OIDC_VERIFY_SIGNATURE = true;
 // This defaults to the APIGW url but if you're using custom DNS you should set this to that
-export const OIDC_REDIRECT_URI = undefined;
+export const OIDC_REDIRECT_URI = '';
 // Optional system banner which will be displayed at the top and the bottom of MLSpace
 export const SYSTEM_BANNER_BACKGROUND_COLOR = 'black';
 export const SYSTEM_BANNER_TEXT = '';   // If this value is not set then no banner will be displayed

--- a/lib/stacks/api/admin.ts
+++ b/lib/stacks/api/admin.ts
@@ -17,11 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import {
-    COMMON_LAYER_ARN_PARAM,
-    NEW_USERS_SUSPENDED,
-    NOTEBOOK_PARAMETERS_FILE_NAME,
-} from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -37,7 +32,7 @@ export class AdminApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -67,7 +62,7 @@ export class AdminApiStack extends Stack {
                 path: 'user',
                 method: 'POST',
                 environment: {
-                    NEW_USER_SUSPENSION_DEFAULT: NEW_USERS_SUSPENDED ? 'True' : 'False',
+                    NEW_USER_SUSPENSION_DEFAULT: props.mlspaceConfig.NEW_USERS_SUSPENDED ? 'True' : 'False',
                 },
             },
             {
@@ -100,7 +95,7 @@ export class AdminApiStack extends Stack {
                 method: 'GET',
                 environment: {
                     BUCKET: props.configBucketName,
-                    S3_KEY: NOTEBOOK_PARAMETERS_FILE_NAME,
+                    S3_KEY: props.mlspaceConfig.NOTEBOOK_PARAMETERS_FILE_NAME,
                 },
             },
             {
@@ -158,7 +153,7 @@ export class AdminApiStack extends Stack {
                 method: 'GET',
                 environment: {
                     BUCKET: props.configBucketName,
-                    S3_KEY: NOTEBOOK_PARAMETERS_FILE_NAME,
+                    S3_KEY: props.mlspaceConfig.NOTEBOOK_PARAMETERS_FILE_NAME,
                 },
             },
             {
@@ -190,6 +185,7 @@ export class AdminApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/datasets.ts
+++ b/lib/stacks/api/datasets.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class DatasetsApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -139,6 +138,7 @@ export class DatasetsApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/emr.ts
+++ b/lib/stacks/api/emr.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class EmrApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -78,6 +77,7 @@ export class EmrApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/inference.ts
+++ b/lib/stacks/api/inference.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class InferenceApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -157,6 +156,7 @@ export class InferenceApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/jobs.ts
+++ b/lib/stacks/api/jobs.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class JobsApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -163,6 +162,7 @@ export class JobsApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/notebooks.ts
+++ b/lib/stacks/api/notebooks.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class NotebooksApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -140,6 +139,7 @@ export class NotebooksApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/projects.ts
+++ b/lib/stacks/api/projects.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM, EMR_SECURITY_CONFIG_NAME } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class ProjectsApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -203,7 +202,7 @@ export class ProjectsApiStack extends Stack {
                 environment: {
                     BUCKET: props.configBucketName,
                     S3_KEY: props.notebookParamFileKey,
-                    EMR_SECURITY_CONFIGURATION: EMR_SECURITY_CONFIG_NAME,
+                    EMR_SECURITY_CONFIGURATION: props.mlspaceConfig.EMR_SECURITY_CONFIG_NAME,
                     EMR_EC2_ROLE_NAME: props.emrEC2RoleName || '',
                     EMR_SERVICE_ROLE_NAME: props.emrServiceRoleName || '',
                     DATA_BUCKET: props.dataBucketName,
@@ -231,6 +230,7 @@ export class ProjectsApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/api/restApi.ts
+++ b/lib/stacks/api/restApi.ts
@@ -35,25 +35,9 @@ import { LogGroup } from 'aws-cdk-lib/aws-logs';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import {
-    ADDITIONAL_LAMBDA_ENVIRONMENT_VARS,
-    APPLICATION_NAME,
-    BUCKET_DEPLOYMENT_ROLE_ARN,
-    COMMON_LAYER_ARN_PARAM,
-    ENABLE_ACCESS_LOGGING,
-    ENABLE_GROUNDTRUTH,
-    IDP_ENDPOINT_SSM_PARAM,
-    INTERNAL_OIDC_URL,
-    LAMBDA_ARCHITECTURE,
-    LAMBDA_RUNTIME,
-    MANAGE_IAM_ROLES,
-    OIDC_CLIENT_NAME,
-    OIDC_REDIRECT_URI,
-    OIDC_URL,
-    OIDC_VERIFY_SSL
-} from '../../constants';
 import { ADCLambdaCABundleAspect } from '../../utils/adcCertBundleAspect';
 import { createLambdaLayer } from '../../utils/layers';
+import { MLSpaceConfig } from '../../utils/configTypes';
 
 export type SystemBannerConfiguration = {
     readonly text?: string;
@@ -78,6 +62,7 @@ export type ApiStackProperties = {
     readonly permissionsBoundaryArn?: string;
     readonly emrEC2RoleName?: string;
     readonly emrServiceRoleName?: string;
+    readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
 
 export type RestApiStackProperties = {
@@ -94,6 +79,7 @@ export type RestApiStackProperties = {
     readonly enableMigrationUI?: boolean;
     readonly enableTranslate: boolean;
     readonly systemBannerConfiguration: SystemBannerConfiguration;
+    readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
 
 export class RestApiStack extends Stack {
@@ -115,7 +101,7 @@ export class RestApiStack extends Stack {
             throttlingRateLimit: 100,
             throttlingBurstLimit: 100,
         };
-        if (ENABLE_ACCESS_LOGGING) {
+        if (props.mlspaceConfig.ENABLE_ACCESS_LOGGING) {
             const apiAccessLogGroup = new LogGroup(this, 'mlspace-APIGWLogGroup', {
                 logGroupName: '/aws/apigateway/MLSpace',
                 removalPolicy: RemovalPolicy.DESTROY,
@@ -260,17 +246,17 @@ export class RestApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         let ssmIdPEndpoint;
-        if (IDP_ENDPOINT_SSM_PARAM) {
-            ssmIdPEndpoint = StringParameter.valueForStringParameter(this, IDP_ENDPOINT_SSM_PARAM);
+        if (props.mlspaceConfig.IDP_ENDPOINT_SSM_PARAM) {
+            ssmIdPEndpoint = StringParameter.valueForStringParameter(this, props.mlspaceConfig.IDP_ENDPOINT_SSM_PARAM);
         }
 
         const authorizerLambda = new Function(this, 'MLSpaceAuthorizerLambda', {
-            runtime: LAMBDA_RUNTIME,
-            architecture: LAMBDA_ARCHITECTURE,
+            runtime: props.mlspaceConfig.LAMBDA_RUNTIME,
+            architecture: props.mlspaceConfig.LAMBDA_ARCHITECTURE,
             handler: 'ml_space_lambda.authorizer.lambda_function.lambda_handler',
             functionName: 'mls-lambda-authorizer',
             code: Code.fromAsset(props.lambdaSourcePath),
@@ -280,11 +266,11 @@ export class RestApiStack extends Stack {
             role: props.mlSpaceAppRole,
             layers: [jwtDependencyLayer.layerVersion, commonLambdaLayer],
             environment: {
-                OIDC_URL: ssmIdPEndpoint || INTERNAL_OIDC_URL || OIDC_URL,
-                OIDC_CLIENT_NAME,
-                OIDC_VERIFY_SSL: OIDC_VERIFY_SSL ? 'True' : 'False',
+                OIDC_URL: ssmIdPEndpoint || props.mlspaceConfig.INTERNAL_OIDC_URL || props.mlspaceConfig.OIDC_URL,
+                OIDC_CLIENT_NAME: props.mlspaceConfig.OIDC_CLIENT_NAME,
+                OIDC_VERIFY_SSL: props.mlspaceConfig.OIDC_VERIFY_SSL ? 'True' : 'False',
                 OIDC_VERIFY_SIGNATURE: props.verifyOIDCTokenSignature ? 'True' : 'False',
-                ...ADDITIONAL_LAMBDA_ENVIRONMENT_VARS,
+                ...props.mlspaceConfig.ADDITIONAL_LAMBDA_ENVIRONMENT_VARS,
             },
             vpc: props.mlSpaceVPC,
             securityGroups: props.lambdaSecurityGroups,
@@ -298,16 +284,16 @@ export class RestApiStack extends Stack {
 
         // Dynamic config relies on api URL and we don't want to do this in a separate stack
         const appEnvironmentConfig = {
-            OIDC_URL: ssmIdPEndpoint || OIDC_URL,
-            OIDC_REDIRECT_URI: OIDC_REDIRECT_URI || mlSpaceRestApi.url,
-            OIDC_CLIENT_NAME,
+            OIDC_URL: ssmIdPEndpoint ||  props.mlspaceConfig.OIDC_URL,
+            OIDC_REDIRECT_URI:  props.mlspaceConfig.OIDC_REDIRECT_URI || mlSpaceRestApi.url,
+            OIDC_CLIENT_NAME:  props.mlspaceConfig.OIDC_CLIENT_NAME,
             LAMBDA_ENDPOINT: mlSpaceRestApi.url,
-            MANAGE_IAM_ROLES,
+            MANAGE_IAM_ROLES:  props.mlspaceConfig.MANAGE_IAM_ROLES,
             SHOW_MIGRATION_OPTIONS: props.enableMigrationUI,
             ENABLE_TRANSLATE: props.enableTranslate,
-            ENABLE_GROUNDTRUTH: ENABLE_GROUNDTRUTH,
+            ENABLE_GROUNDTRUTH: props.mlspaceConfig.ENABLE_GROUNDTRUTH,
             SYSTEM_BANNER: props.systemBannerConfiguration,
-            APPLICATION_NAME: APPLICATION_NAME,
+            APPLICATION_NAME: props.mlspaceConfig.APPLICATION_NAME,
             DATASET_BUCKET: props.dataBucketName
         };
 
@@ -325,11 +311,11 @@ export class RestApiStack extends Stack {
             ],
             destinationBucket: websiteBucket,
             prune: true,
-            role: BUCKET_DEPLOYMENT_ROLE_ARN
+            role: props.mlspaceConfig.BUCKET_DEPLOYMENT_ROLE_ARN
                 ? Role.fromRoleArn(
                     this,
                     'mlspace-website-deploy-role',
-                    BUCKET_DEPLOYMENT_ROLE_ARN,
+                    props.mlspaceConfig.BUCKET_DEPLOYMENT_ROLE_ARN,
                     {
                         mutable: false,
                     }

--- a/lib/stacks/api/translate.ts
+++ b/lib/stacks/api/translate.ts
@@ -17,7 +17,6 @@
 import { App, Stack } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import { COMMON_LAYER_ARN_PARAM } from '../../constants';
 import { MLSpacePythonLambdaFunction, registerAPIEndpoint } from '../../utils/apiFunction';
 import { ApiStackProperties } from './restApi';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
@@ -33,7 +32,7 @@ export class TranslateApiStack extends Stack {
         const commonLambdaLayer = LayerVersion.fromLayerVersionArn(
             this,
             'mls-common-lambda-layer',
-            StringParameter.valueForStringParameter(this, COMMON_LAYER_ARN_PARAM)
+            StringParameter.valueForStringParameter(this, props.mlspaceConfig.COMMON_LAYER_ARN_PARAM)
         );
 
         const restApi = RestApi.fromRestApiAttributes(this, 'RestApi', {
@@ -113,6 +112,7 @@ export class TranslateApiStack extends Stack {
                 f,
                 props.mlSpaceVPC,
                 props.securityGroups,
+                props.mlspaceConfig,
                 props.permissionsBoundaryArn
             );
         });

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -29,19 +29,7 @@ import {
     ServicePrincipal
 } from 'aws-cdk-lib/aws-iam';
 import { IKey } from 'aws-cdk-lib/aws-kms';
-import {
-    APIGATEWAY_CLOUDWATCH_ROLE_ARN,
-    APP_ROLE_ARN,
-    EMR_DEFAULT_ROLE_ARN,
-    EMR_EC2_INSTANCE_ROLE_ARN,
-    ENABLE_ACCESS_LOGGING,
-    IAM_RESOURCE_PREFIX,
-    MANAGE_IAM_ROLES,
-    NOTEBOOK_ROLE_ARN,
-    PERMISSIONS_BOUNDARY_POLICY_NAME,
-    S3_READER_ROLE_ARN,
-    SYSTEM_TAG
-} from '../constants';
+import { MLSpaceConfig } from '../utils/configTypes';
 
 export type IAMStackProp = {
     readonly dataBucketName: string;
@@ -52,6 +40,7 @@ export type IAMStackProp = {
     readonly mlSpaceDefaultSecurityGroupId: string;
     readonly enableTranslate: boolean;
     readonly isIso?: boolean;
+    readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
 
 export class IAMStack extends Stack {
@@ -360,14 +349,14 @@ export class IAMStack extends Stack {
                     },
                 }),
             ];
-
+            
             if (props.enableTranslate) {
                 statements.push(translateIAMPermissionsPolicyStatement);
                 statements.push(new PolicyStatement({
                     effect: Effect.ALLOW,
                     actions: ['iam:PassRole'],
                     resources: [
-                        `arn:${this.partition}:iam::${this.account}:role/${IAM_RESOURCE_PREFIX}*`,
+                        `arn:${this.partition}:iam::${this.account}:role/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`,
                     ],
                     conditions: {
                         StringEquals: {
@@ -382,7 +371,7 @@ export class IAMStack extends Stack {
             * IAM roles then the user/project policies that get attached to the dynamically created
             * notebook role will lock things down to global, project, and user levels.
             */
-            if (!MANAGE_IAM_ROLES) {
+            if (!props.mlspaceConfig.MANAGE_IAM_ROLES) {
                 statements.push(
                     new PolicyStatement({
                         effect: Effect.ALLOW,
@@ -398,11 +387,11 @@ export class IAMStack extends Stack {
             statements: notebookPolicyStatements(this.partition, Aws.REGION),
         });
 
-        if (NOTEBOOK_ROLE_ARN) {
+        if (props.mlspaceConfig.NOTEBOOK_ROLE_ARN) {
             this.mlSpaceNotebookRole = Role.fromRoleArn(
                 this,
                 'mlspace-notebook-role',
-                NOTEBOOK_ROLE_ARN
+                props.mlspaceConfig.NOTEBOOK_ROLE_ARN
             );
         } else {
             const mlSpaceNotebookRoleName = 'mlspace-notebook-role';
@@ -423,12 +412,12 @@ export class IAMStack extends Stack {
         }
 
         /* App Role depends on permissions boundary */
-        if (MANAGE_IAM_ROLES) {
-            if (PERMISSIONS_BOUNDARY_POLICY_NAME) {
+        if (props.mlspaceConfig.MANAGE_IAM_ROLES) {
+            if (props.mlspaceConfig.PERMISSIONS_BOUNDARY_POLICY_NAME) {
                 this.mlSpacePermissionsBoundary = ManagedPolicy.fromManagedPolicyName(
                     this,
                     'mlspace-existing-boundary',
-                    PERMISSIONS_BOUNDARY_POLICY_NAME
+                    props.mlspaceConfig.PERMISSIONS_BOUNDARY_POLICY_NAME
                 );
             } else {
                 const passRolePrincipals = props.enableTranslate
@@ -491,7 +480,7 @@ export class IAMStack extends Stack {
                                 *
                                 * This needs to match the IAM_RESOURCE_PREFIX prefix in iam_manager.py
                                 */
-                                resources: [`arn:*:iam::${this.account}:role/${IAM_RESOURCE_PREFIX}*`],
+                                resources: [`arn:*:iam::${this.account}:role/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`],
                                 conditions: {
                                     StringEquals: {
                                         'iam:PassedToService': passRolePrincipals,
@@ -505,8 +494,8 @@ export class IAMStack extends Stack {
             }
         }
 
-        if (APP_ROLE_ARN) {
-            this.mlSpaceAppRole = Role.fromRoleArn(this, 'mlspace-app-role', APP_ROLE_ARN);
+        if (props.mlspaceConfig.APP_ROLE_ARN) {
+            this.mlSpaceAppRole = Role.fromRoleArn(this, 'mlspace-app-role', props.mlspaceConfig.APP_ROLE_ARN);
         } else {
             // ML Space Application role
             const mlSpaceAppRoleName = 'mlspace-app-role';
@@ -745,17 +734,17 @@ export class IAMStack extends Stack {
                 appPolicy.addStatements(translateIAMPermissionsPolicyStatement);
             }
 
-            if (MANAGE_IAM_ROLES && this.mlSpacePermissionsBoundary) {
+            if (props.mlspaceConfig.MANAGE_IAM_ROLES && this.mlSpacePermissionsBoundary) {
                 appPolicy.addStatements(
                     new PolicyStatement({
                         effect: Effect.ALLOW,
                         actions: ['iam:CreateRole'],
                         resources: [
-                            `arn:${this.partition}:iam::${this.account}:role/${IAM_RESOURCE_PREFIX}*`,
+                            `arn:${this.partition}:iam::${this.account}:role/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`,
                         ],
                         conditions: {
                             StringEqualsIgnoreCase: {
-                                'iam:ResourceTag/system': SYSTEM_TAG,
+                                'iam:ResourceTag/system': props.mlspaceConfig.SYSTEM_TAG,
                             },
                             StringEquals: {
                                 'iam:PermissionsBoundary':
@@ -774,11 +763,11 @@ export class IAMStack extends Stack {
                         ],
                         // This needs to match the IAM_RESOURCE_PREFIX prefix in iam_manager.py
                         resources: [
-                            `arn:${this.partition}:iam::${this.account}:role/${IAM_RESOURCE_PREFIX}*`,
+                            `arn:${this.partition}:iam::${this.account}:role/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`,
                         ],
                         conditions: {
                             StringEqualsIgnoreCase: {
-                                'iam:ResourceTag/system': SYSTEM_TAG,
+                                'iam:ResourceTag/system': props.mlspaceConfig.SYSTEM_TAG,
                             },
                         },
                     }),
@@ -805,14 +794,14 @@ export class IAMStack extends Stack {
                         ],
                         // This needs to match the IAM_RESOURCE_PREFIX prefix in iam_manager.py
                         resources: [
-                            `arn:${this.partition}:iam::${this.account}:policy/${IAM_RESOURCE_PREFIX}*`,
+                            `arn:${this.partition}:iam::${this.account}:policy/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`,
                         ],
                     }),
                     new PolicyStatement({
                         effect: Effect.ALLOW,
                         actions: ['iam:SimulatePrincipalPolicy', 'iam:TagRole'],
                         resources: [
-                            `arn:${this.partition}:iam::${this.account}:role/${IAM_RESOURCE_PREFIX}*`,
+                            `arn:${this.partition}:iam::${this.account}:role/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`,
                         ],
                     }),
                     /*
@@ -829,7 +818,7 @@ export class IAMStack extends Stack {
                         effect: Effect.ALLOW,
                         actions: ['iam:PassRole'],
                         resources: [
-                            `arn:${this.partition}:iam::${this.account}:role/${IAM_RESOURCE_PREFIX}*`,
+                            `arn:${this.partition}:iam::${this.account}:role/${props.mlspaceConfig.IAM_RESOURCE_PREFIX}*`,
                         ],
                         conditions: {
                             StringEquals: {
@@ -879,11 +868,11 @@ export class IAMStack extends Stack {
             });
         }
 
-        if (S3_READER_ROLE_ARN) {
+        if (props.mlspaceConfig.S3_READER_ROLE_ARN) {
             this.s3ReaderRole = Role.fromRoleArn(
                 this,
                 'mlspace-s3-reader-role',
-                S3_READER_ROLE_ARN
+                props.mlspaceConfig.S3_READER_ROLE_ARN
             );
         } else {
             const s3WebsiteReadOnlyPolicy = new ManagedPolicy(this, 'mlspace-website-read-policy', {
@@ -903,10 +892,10 @@ export class IAMStack extends Stack {
             });
         }
 
-        if (ENABLE_ACCESS_LOGGING) {
-            if (APIGATEWAY_CLOUDWATCH_ROLE_ARN) {
+        if (props.mlspaceConfig.ENABLE_ACCESS_LOGGING) {
+            if (props.mlspaceConfig.APIGATEWAY_CLOUDWATCH_ROLE_ARN) {
                 new CfnAccount(this, 'mlspace-cwl-api-gateway-account', {
-                    cloudWatchRoleArn: APIGATEWAY_CLOUDWATCH_ROLE_ARN,
+                    cloudWatchRoleArn: props.mlspaceConfig.APIGATEWAY_CLOUDWATCH_ROLE_ARN,
                 });
             } else {
                 // Create CW Role
@@ -925,11 +914,11 @@ export class IAMStack extends Stack {
             }
         }
 
-        if (EMR_DEFAULT_ROLE_ARN) {
+        if (props.mlspaceConfig.EMR_DEFAULT_ROLE_ARN) {
             const existingEmrServiceRole = Role.fromRoleArn(
                 this,
                 'mlspace-emr_defaultrole',
-                EMR_DEFAULT_ROLE_ARN
+                props.mlspaceConfig.EMR_DEFAULT_ROLE_ARN
             );
             this.emrServiceRoleName = existingEmrServiceRole.roleName;
         } else {
@@ -947,11 +936,11 @@ export class IAMStack extends Stack {
             this.emrServiceRoleName = serviceRoleName;
         }
 
-        if (EMR_EC2_INSTANCE_ROLE_ARN) {
+        if (props.mlspaceConfig.EMR_EC2_INSTANCE_ROLE_ARN) {
             const existingEmrEC2Role = Role.fromRoleArn(
                 this,
                 'mlspace-emr_ec2_defaultrole',
-                EMR_EC2_INSTANCE_ROLE_ARN
+                props.mlspaceConfig.EMR_EC2_INSTANCE_ROLE_ARN
             );
             this.emrEC2RoleName = existingEmrEC2Role.roleName;
         } else {

--- a/lib/stacks/infra/sagemaker.ts
+++ b/lib/stacks/infra/sagemaker.ts
@@ -17,15 +17,11 @@
 import { App, Fn, Stack, StackProps } from 'aws-cdk-lib';
 import { CfnNotebookInstanceLifecycleConfig } from 'aws-cdk-lib/aws-sagemaker';
 import { readFileSync } from 'fs';
-import {
-    MLSPACE_LIFECYCLE_CONFIG_NAME,
-    SYSTEM_BANNER_BACKGROUND_COLOR,
-    SYSTEM_BANNER_TEXT,
-    SYSTEM_BANNER_TEXT_COLOR
-} from '../../constants';
+import { MLSpaceConfig } from '../../utils/configTypes';
 
 export type SagemakerStackProp = {
     readonly dataBucketName: string;
+    readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
 
 export class SagemakerStack extends Stack {
@@ -36,7 +32,7 @@ export class SagemakerStack extends Stack {
         });
 
         new CfnNotebookInstanceLifecycleConfig(this, 'mlspace-notebook-lifecycle-config', {
-            notebookInstanceLifecycleConfigName: MLSPACE_LIFECYCLE_CONFIG_NAME,
+            notebookInstanceLifecycleConfigName: props.mlspaceConfig.MLSPACE_LIFECYCLE_CONFIG_NAME,
             onCreate: [
                 {
                     content: Fn.base64(
@@ -51,12 +47,12 @@ export class SagemakerStack extends Stack {
                 {
                     content: Fn.base64(
                         readFileSync('lib/resources/sagemaker/lifecycle-start.sh', 'utf8')
-                            .replace(/<BANNER_COLOR>/g, SYSTEM_BANNER_BACKGROUND_COLOR)
+                            .replace(/<BANNER_COLOR>/g, props.mlspaceConfig.SYSTEM_BANNER_BACKGROUND_COLOR)
                             .replace(
                                 /<BANNER_TEXT_COLOR>/g,
-                                SYSTEM_BANNER_TEXT_COLOR
+                                props.mlspaceConfig.SYSTEM_BANNER_TEXT_COLOR
                             )
-                            .replace(/<BANNER_TEXT>/g, SYSTEM_BANNER_TEXT)
+                            .replace(/<BANNER_TEXT>/g, props.mlspaceConfig.SYSTEM_BANNER_TEXT)
                     ),
                 },
             ],

--- a/lib/stacks/kms.ts
+++ b/lib/stacks/kms.ts
@@ -23,10 +23,11 @@ import {
     Role,
 } from 'aws-cdk-lib/aws-iam';
 import { IKey, Key } from 'aws-cdk-lib/aws-kms';
-import { EXISTING_KMS_MASTER_KEY_ARN } from '../constants';
+import { MLSpaceConfig } from '../utils/configTypes';
 
 export type KMSStackProp = {
     readonly keyManagerRoleName: string;
+    readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
 
 export class KMSStack extends Stack {
@@ -38,8 +39,8 @@ export class KMSStack extends Stack {
             ...props,
         });
 
-        if (EXISTING_KMS_MASTER_KEY_ARN) {
-            this.masterKey = Key.fromKeyArn(this, 'imported-kms-key', EXISTING_KMS_MASTER_KEY_ARN);
+        if (props.mlspaceConfig.EXISTING_KMS_MASTER_KEY_ARN) {
+            this.masterKey = Key.fromKeyArn(this, 'imported-kms-key', props.mlspaceConfig.EXISTING_KMS_MASTER_KEY_ARN);
         } else {
             this.masterKey = new Key(this, 'mlspace-kms-key', {
                 policy: new PolicyDocument({

--- a/lib/stacks/vpc.ts
+++ b/lib/stacks/vpc.ts
@@ -25,11 +25,7 @@ import {
     SubnetType,
     Vpc,
 } from 'aws-cdk-lib/aws-ec2';
-import {
-    EXISTING_VPC_DEFAULT_SECURITY_GROUP,
-    EXISTING_VPC_ID,
-    EXISTING_VPC_NAME,
-} from '../constants';
+import { MLSpaceConfig } from '../utils/configTypes';
 
 export type VPCStackProps = {
     readonly deployCFNEndpoint: boolean;
@@ -39,6 +35,7 @@ export type VPCStackProps = {
     readonly deployS3Endpoint: boolean;
     readonly deploySTSEndpoint: boolean;
     readonly isIso?: boolean;
+    readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
 export class VPCStack extends Stack {
     public readonly vpc: IVpc;
@@ -55,12 +52,12 @@ export class VPCStack extends Stack {
         const isIsoEast = this.region === 'us-iso-east-1';
         const isIsoWest = this.region === 'us-iso-west-1';
 
-        if (EXISTING_VPC_NAME && EXISTING_VPC_ID && EXISTING_VPC_DEFAULT_SECURITY_GROUP) {
+        if (props.mlspaceConfig.EXISTING_VPC_NAME && props.mlspaceConfig.EXISTING_VPC_ID && props.mlspaceConfig.EXISTING_VPC_DEFAULT_SECURITY_GROUP) {
             this.vpc = Vpc.fromLookup(this, 'imported-vpc', {
-                vpcId: EXISTING_VPC_ID,
-                vpcName: EXISTING_VPC_NAME,
+                vpcId: props.mlspaceConfig.EXISTING_VPC_ID,
+                vpcName: props.mlspaceConfig.EXISTING_VPC_NAME,
             });
-            this.vpcSecurityGroupId = EXISTING_VPC_DEFAULT_SECURITY_GROUP;
+            this.vpcSecurityGroupId = props.mlspaceConfig.EXISTING_VPC_DEFAULT_SECURITY_GROUP;
         } else {
             const mlSpaceVPC = new Vpc(this, 'MLSpace-VPC', {
                 enableDnsHostnames: true,

--- a/lib/utils/configTypes.ts
+++ b/lib/utils/configTypes.ts
@@ -1,0 +1,238 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+import _ = require('lodash');
+import {
+    ACCESS_LOGS_BUCKET_NAME,
+    ADDITIONAL_LAMBDA_ENVIRONMENT_VARS,
+    APIGATEWAY_CLOUDWATCH_ROLE_ARN,
+    APPLICATION_NAME,
+    APP_ROLE_ARN,
+    AWS_ACCOUNT,
+    AWS_REGION,
+    BUCKET_DEPLOYMENT_ROLE_ARN,
+    COMMON_LAYER_ARN_PARAM,
+    CONFIG_BUCKET_NAME,
+    CREATE_MLSPACE_CLOUDTRAIL_TRAIL,
+    DATASETS_TABLE_NAME,
+    DATA_BUCKET_NAME,
+    EMR_DEFAULT_ROLE_ARN,
+    EMR_EC2_INSTANCE_ROLE_ARN,
+    EMR_SECURITY_CONFIG_NAME,
+    ENABLE_ACCESS_LOGGING,
+    ENABLE_GROUNDTRUTH,
+    ENABLE_TRANSLATE,
+    EXISTING_KMS_MASTER_KEY_ARN,
+    EXISTING_VPC_DEFAULT_SECURITY_GROUP,
+    EXISTING_VPC_ID,
+    EXISTING_VPC_NAME,
+    IAM_RESOURCE_PREFIX,
+    IDP_ENDPOINT_SSM_PARAM,
+    INTERNAL_OIDC_URL,
+    KEY_MANAGER_ROLE_NAME,
+    LAMBDA_ARCHITECTURE,
+    LAMBDA_RUNTIME,
+    LOGS_BUCKET_NAME,
+    MANAGE_IAM_ROLES,
+    MLSPACE_LIFECYCLE_CONFIG_NAME,
+    NEW_USERS_SUSPENDED,
+    NOTEBOOK_PARAMETERS_FILE_NAME,
+    NOTEBOOK_ROLE_ARN,
+    NOTIFICATION_DISTRO,
+    OIDC_CLIENT_NAME,
+    OIDC_REDIRECT_URI,
+    OIDC_URL,
+    OIDC_VERIFY_SIGNATURE,
+    OIDC_VERIFY_SSL,
+    PERMISSIONS_BOUNDARY_POLICY_NAME,
+    PROJECTS_TABLE_NAME,
+    PROJECT_USERS_TABLE_NAME,
+    RESOURCE_METADATA_TABLE_NAME,
+    RESOURCE_SCHEDULE_TABLE_NAME,
+    RESOURCE_TERMINATION_INTERVAL,
+    S3_READER_ROLE_ARN,
+    SYSTEM_BANNER_BACKGROUND_COLOR,
+    SYSTEM_BANNER_TEXT,
+    SYSTEM_BANNER_TEXT_COLOR,
+    SYSTEM_TAG,
+    USERS_TABLE_NAME,
+    WEBSITE_BUCKET_NAME
+} from '../constants';
+import * as fs from "fs";
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+
+export interface MLSpaceConfig {
+    //Table names
+    DATASETS_TABLE_NAME: string,
+    PROJECTS_TABLE_NAME: string,
+    PROJECT_USERS_TABLE_NAME: string,
+    USERS_TABLE_NAME: string,
+    RESOURCE_SCHEDULE_TABLE_NAME: string,
+    RESOURCE_METADATA_TABLE_NAME: string
+    //Bucket names
+    CONFIG_BUCKET_NAME: string,
+    DATA_BUCKET_NAME: string,
+    LOGS_BUCKET_NAME: string,
+    ACCESS_LOGS_BUCKET_NAME: string,
+    WEBSITE_BUCKET_NAME:string,
+    //Notebook settings
+    MLSPACE_LIFECYCLE_CONFIG_NAME: string,
+    NOTEBOOK_PARAMETERS_FILE_NAME: string,
+    // EMR settings
+    EMR_SECURITY_CONFIG_NAME: string,
+    // OIDC settings
+    IDP_ENDPOINT_SSM_PARAM: string,
+    INTERNAL_OIDC_URL: string,
+    OIDC_VERIFY_SSL: boolean,
+    OIDC_VERIFY_SIGNATURE: boolean,
+    OIDC_REDIRECT_URI: string,
+    // Other properties not handled in config.json
+    SYSTEM_TAG: string,
+    IAM_RESOURCE_PREFIX: string,
+    APPLICATION_NAME: string,
+    PERMISSIONS_BOUNDARY_POLICY_NAME: string,
+    KEY_MANAGER_ROLE_NAME: string,
+    NOTIFICATION_DISTRO: string,
+    EXISTING_KMS_MASTER_KEY_ARN: string,
+    APIGATEWAY_CLOUDWATCH_ROLE_ARN: string,
+    COMMON_LAYER_ARN_PARAM: string,
+    ADDITIONAL_LAMBDA_ENVIRONMENT_VARS: { [key: string]: string }
+    MANAGE_IAM_ROLES: boolean,
+    ENABLE_ACCESS_LOGGING: boolean,
+    CREATE_MLSPACE_CLOUDTRAIL_TRAIL: boolean,
+    ENABLE_TRANSLATE: boolean,
+    ENABLE_GROUNDTRUTH: boolean,
+    RESOURCE_TERMINATION_INTERVAL: number,
+    NEW_USERS_SUSPENDED: boolean,
+    LAMBDA_ARCHITECTURE: Architecture,
+    LAMBDA_RUNTIME: Runtime,
+    //Properties that can optionally be set in config.json
+    AWS_ACCOUNT: string,
+    AWS_REGION: string,
+    OIDC_URL:  string,
+    OIDC_CLIENT_NAME: string,
+    EXISTING_VPC_NAME: string,
+    EXISTING_VPC_ID: string,
+    EXISTING_VPC_DEFAULT_SECURITY_GROUP: string,
+    S3_READER_ROLE_ARN: string,
+    BUCKET_DEPLOYMENT_ROLE_ARN: string,
+    NOTEBOOK_ROLE_ARN: string,
+    APP_ROLE_ARN: string,
+    EMR_DEFAULT_ROLE_ARN: string,
+    EMR_EC2_INSTANCE_ROLE_ARN: string,
+    SYSTEM_BANNER_BACKGROUND_COLOR: string,
+    SYSTEM_BANNER_TEXT: string,
+    SYSTEM_BANNER_TEXT_COLOR: string,
+}
+
+const validateRequiredProperty = (val: string, name: string) => {
+    if (!val) {
+        throw new Error(`${name} is a required property. \nPlease run 'npm run config'` +
+        `and select the Basic Configuration option, which will walk you through setting up all required fields`);
+    }
+};
+
+/**
+ * Generates an MLSpaceConfig object containing settings from config.json (if it exists), 
+ * or defaulting to settings in constants.ts if that property hasn't been set
+ * in config.json
+ */
+export function generateConfig () {
+    let config: MLSpaceConfig = {
+        // Table names
+        DATASETS_TABLE_NAME: DATASETS_TABLE_NAME,
+        PROJECTS_TABLE_NAME: PROJECTS_TABLE_NAME,
+        PROJECT_USERS_TABLE_NAME: PROJECT_USERS_TABLE_NAME,
+        USERS_TABLE_NAME: USERS_TABLE_NAME,
+        RESOURCE_SCHEDULE_TABLE_NAME: RESOURCE_SCHEDULE_TABLE_NAME,
+        RESOURCE_METADATA_TABLE_NAME: RESOURCE_METADATA_TABLE_NAME,
+        // Bucket names
+        CONFIG_BUCKET_NAME: CONFIG_BUCKET_NAME,
+        DATA_BUCKET_NAME: DATA_BUCKET_NAME,
+        LOGS_BUCKET_NAME: LOGS_BUCKET_NAME,
+        ACCESS_LOGS_BUCKET_NAME: ACCESS_LOGS_BUCKET_NAME,
+        WEBSITE_BUCKET_NAME: WEBSITE_BUCKET_NAME,
+        // Notebook settings
+        MLSPACE_LIFECYCLE_CONFIG_NAME: MLSPACE_LIFECYCLE_CONFIG_NAME,
+        NOTEBOOK_PARAMETERS_FILE_NAME: NOTEBOOK_PARAMETERS_FILE_NAME,
+        // EMR settings
+        EMR_SECURITY_CONFIG_NAME: EMR_SECURITY_CONFIG_NAME,
+        // OIDC settings
+        IDP_ENDPOINT_SSM_PARAM: IDP_ENDPOINT_SSM_PARAM,
+        INTERNAL_OIDC_URL: INTERNAL_OIDC_URL,
+        OIDC_VERIFY_SSL: OIDC_VERIFY_SSL,
+        OIDC_VERIFY_SIGNATURE: OIDC_VERIFY_SIGNATURE,
+        OIDC_REDIRECT_URI: OIDC_REDIRECT_URI,
+        // Other properties not prompted for in config-helper
+        SYSTEM_TAG: SYSTEM_TAG,
+        IAM_RESOURCE_PREFIX: IAM_RESOURCE_PREFIX,
+        APPLICATION_NAME: APPLICATION_NAME,
+        PERMISSIONS_BOUNDARY_POLICY_NAME: PERMISSIONS_BOUNDARY_POLICY_NAME,
+        NOTIFICATION_DISTRO: NOTIFICATION_DISTRO,
+        EXISTING_KMS_MASTER_KEY_ARN: EXISTING_KMS_MASTER_KEY_ARN,
+        APIGATEWAY_CLOUDWATCH_ROLE_ARN: APIGATEWAY_CLOUDWATCH_ROLE_ARN,
+        COMMON_LAYER_ARN_PARAM: COMMON_LAYER_ARN_PARAM,
+        ADDITIONAL_LAMBDA_ENVIRONMENT_VARS: ADDITIONAL_LAMBDA_ENVIRONMENT_VARS,
+        MANAGE_IAM_ROLES: MANAGE_IAM_ROLES,
+        ENABLE_ACCESS_LOGGING: ENABLE_ACCESS_LOGGING,
+        CREATE_MLSPACE_CLOUDTRAIL_TRAIL: CREATE_MLSPACE_CLOUDTRAIL_TRAIL,
+        ENABLE_TRANSLATE: ENABLE_TRANSLATE,
+        ENABLE_GROUNDTRUTH: ENABLE_GROUNDTRUTH,
+        RESOURCE_TERMINATION_INTERVAL: RESOURCE_TERMINATION_INTERVAL,
+        LAMBDA_ARCHITECTURE: LAMBDA_ARCHITECTURE,
+        LAMBDA_RUNTIME: LAMBDA_RUNTIME,
+        //Properties that are prompted for in the config-helper wizard
+        AWS_ACCOUNT: AWS_ACCOUNT,
+        AWS_REGION: AWS_REGION,
+        OIDC_URL:  OIDC_URL,
+        OIDC_CLIENT_NAME: OIDC_CLIENT_NAME,
+        KEY_MANAGER_ROLE_NAME: KEY_MANAGER_ROLE_NAME,
+        EXISTING_VPC_NAME: EXISTING_VPC_NAME,
+        EXISTING_VPC_ID: EXISTING_VPC_ID,
+        EXISTING_VPC_DEFAULT_SECURITY_GROUP: EXISTING_VPC_DEFAULT_SECURITY_GROUP,
+        S3_READER_ROLE_ARN: S3_READER_ROLE_ARN,
+        BUCKET_DEPLOYMENT_ROLE_ARN: BUCKET_DEPLOYMENT_ROLE_ARN,
+        NOTEBOOK_ROLE_ARN: NOTEBOOK_ROLE_ARN,
+        APP_ROLE_ARN: APP_ROLE_ARN,
+        EMR_DEFAULT_ROLE_ARN: EMR_DEFAULT_ROLE_ARN,
+        EMR_EC2_INSTANCE_ROLE_ARN: EMR_EC2_INSTANCE_ROLE_ARN,
+        SYSTEM_BANNER_BACKGROUND_COLOR: SYSTEM_BANNER_BACKGROUND_COLOR,
+        SYSTEM_BANNER_TEXT: SYSTEM_BANNER_TEXT,
+        SYSTEM_BANNER_TEXT_COLOR: SYSTEM_BANNER_TEXT_COLOR,
+        NEW_USERS_SUSPENDED: NEW_USERS_SUSPENDED,
+    };
+
+
+    //Check for properties set in config.json and default to that value if it exists
+    if (fs.existsSync('lib/config.json')) {
+        const fileConfig: MLSpaceConfig = JSON.parse(
+            fs.readFileSync('lib/config.json').toString('utf8')
+        );
+        _.merge(config, [fileConfig]);
+    }
+
+    
+
+    validateRequiredProperty(config.AWS_ACCOUNT, 'AWS_ACCOUNT');
+    validateRequiredProperty(config.OIDC_URL, 'OIDC_URL');
+    validateRequiredProperty(config.OIDC_CLIENT_NAME, 'OIDC_CLIENT_NAME');
+    validateRequiredProperty(config.AWS_REGION, 'AWS_REGION');
+
+    if (!config.EXISTING_KMS_MASTER_KEY_ARN) {
+        validateRequiredProperty(config.KEY_MANAGER_ROLE_NAME, 'KEY_MANAGER_ROLE_NAME');
+    }
+
+    return config;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
             "version": "1.0.0",
             "license": "UNLICENSED",
             "dependencies": {
-                "aws-cdk-lib": "^2.93.0"
+                "@types/lodash": "^4.17.0",
+                "aws-cdk-lib": "^2.93.0",
+                "enquirer": "^2.4.1",
+                "figlet": "^1.7.0"
             },
             "devDependencies": {
                 "@aws-sdk/client-s3": "^3.400.0",
@@ -2218,6 +2221,11 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/lodash": {
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+            "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
+        },
         "node_modules/@types/node": {
             "version": "20.11.25",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
@@ -2658,6 +2666,14 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/ansi-escapes": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
@@ -2689,7 +2705,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3446,15 +3461,6 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
-        "node_modules/commander": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3639,6 +3645,18 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/enquirer": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+            "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+            "dependencies": {
+                "ansi-colors": "^4.1.1",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8.6"
             }
         },
         "node_modules/es-abstract": {
@@ -4338,6 +4356,17 @@
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/figlet": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.7.0.tgz",
+            "integrity": "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg==",
+            "bin": {
+                "figlet": "bin/index.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
             }
         },
         "node_modules/file-entry-cache": {
@@ -5306,6 +5335,15 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/commander": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+            "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/listr2": {
@@ -6345,7 +6383,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },

--- a/package.json
+++ b/package.json
@@ -10,18 +10,21 @@
         "watch": "tsc -w",
         "prepare": "npm run-script build",
         "test": "echo 'No Tests'",
-        "lint:fix": "eslint --fix --ext .ts lib/"
+        "lint:fix": "eslint --fix --ext .ts lib/",
+        "config": "node ./bin/scripts/config-helper.js"
     },
     "devDependencies": {
         "@aws-sdk/client-s3": "^3.400.0",
         "@stylistic/eslint-plugin": "^1.5.0",
         "@types/aws-lambda": "8.10.119",
         "@types/jsonwebtoken": "^9.0.2",
+        "@types/lodash": "^4.17.0",
         "@types/node": "*",
         "@typescript-eslint/eslint-plugin": "^5.36.1",
         "@typescript-eslint/parser": "^5.36.1",
         "aws-cdk-lib": "^2.93.0",
         "constructs": "^10.0.97",
+        "enquirer": "^2.4.1",
         "esbuild": "^0.19.2",
         "eslint": "^8.23.0",
         "eslint-import-resolver-typescript": "^3.4.1",
@@ -30,6 +33,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "eslint-plugin-spellcheck": "^0.0.19",
+        "figlet": "^1.7.0",
         "lint-staged": "^13.0.3",
         "typescript": "~4.7.4"
     },


### PR DESCRIPTION
*Issue #, if available:* AIML-ADC-5626

*Description of changes:*

- exposed AWS_REGION from cdk `lib/constants.ts` to frontend `window.env`
- added a check to exclude 'auto' source language detection in unsupported regions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
