### PR TITLE
Enables PCA Algorithm For Training Jobs

### DIFF
--- a/frontend/src/entities/jobs/hpo/create/training-definitions/algorithm-options.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/algorithm-options.tsx
@@ -44,12 +44,6 @@ import _ from 'lodash';
 
 const algorithmNameRegex = new RegExp('/(.*):');
 
-const algorithmOptions = ML_ALGORITHMS.filter(
-    (algorithm) => algorithm.active && algorithm.tunable
-).map((algorithm) => {
-    return { value: algorithm.displayName };
-});
-
 export enum AlgorithmSource {
     BUILT_IN = 'built-in',
     CUSTOM = 'custom',
@@ -82,6 +76,12 @@ export function AlgorithmOptions (props: AlgorithmOptionsProps) {
         props;
     const trainingImages = useAppSelector(selectBuiltinTrainingImages);
     const dispatch = useAppDispatch();
+
+    const algorithmOptions = ML_ALGORITHMS.filter(
+        (algorithm) => algorithm.active && (algorithm.tunable || !isHPO)
+    ).map((algorithm) => {
+        return { value: algorithm.displayName };
+    });
 
     const applyAlgorithm = (algorithm : Algorithm) => {
         const hyperParameters = {} as any;
@@ -147,7 +147,7 @@ export function AlgorithmOptions (props: AlgorithmOptionsProps) {
 
         // Sets MetricDefinitions to the default for the algorithm
         fieldsToSet['AlgorithmSpecification.MetricDefinitions'] =
-            algorithm.metadata.metricDefinitions.map((metric) => {
+            algorithm.metadata.metricDefinitions?.map((metric) => {
                 return {
                     Name: metric.metricName,
                     Regex: metric.metricRegex,
@@ -436,7 +436,7 @@ export function AlgorithmOptions (props: AlgorithmOptionsProps) {
                                 },
                             },
                         ]}
-                        empty='No algorithm selected'
+                        empty='There are currently no resources.'
                         items={item.AlgorithmSpecification?.MetricDefinitions || []}
                     />
                 </Condition>

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/algorithm-options.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/algorithm-options.tsx
@@ -436,7 +436,7 @@ export function AlgorithmOptions (props: AlgorithmOptionsProps) {
                                 },
                             },
                         ]}
-                        empty='There are currently no resources.'
+                        empty={item.AlgorithmSpecification?.AlgorithmName ? 'There are no metrics definitions for the selected algorithm' : 'No algorithm selected'}
                         items={item.AlgorithmSpecification?.MetricDefinitions || []}
                     />
                 </Condition>


### PR DESCRIPTION
*Issue #, if available:* https://issues.amazon.com/issues/AnIMaL-22324

*Description of changes:* Makes PCA selectable again for training jobs
- ML_ALGORITHMS filters tunable differently for training and HPO
- Metrics definitions no longer required (not required [for console](https://code.amazon.com/packages/SageMakerFirstPartyAlgorithmMetadata/blobs/mainline/--/configuration/algometadata/pca/config_console.json))
- Empty Metrics Definitions updated to console message to be more accurate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
