### PR TITLE
added support for container architecture specification

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -66,6 +66,15 @@ export const BUCKET_DEPLOYMENT_ROLE_ARN = '';
  * }
  */
 export const ADDITIONAL_LAMBDA_ENVIRONMENT_VARS: { [key: string]: string } = {};
+
+/*
+ * Optional mechanism for setting the lambda function architecture, default is "x86_64"
+ * change to "arm64" if/as needed based on the CDK build instance architecture
+ */
+export const LAMBDA_CONFIGS: { [key: string]: string } = {
+  architecture: 'x86_64',
+};
+
 /*
  * These roles must already exist in your account and have the required permissions.
  * The value here must be a valid arn similar to 'arn:aws:iam::111111111111:role/mls-notebook'

--- a/lib/stacks/api/restApi.ts
+++ b/lib/stacks/api/restApi.ts
@@ -48,10 +48,13 @@ import {
     OIDC_CLIENT_NAME,
     OIDC_REDIRECT_URI,
     OIDC_URL,
-    OIDC_VERIFY_SSL
+    OIDC_VERIFY_SSL,
+    LAMBDA_CONFIGS,
 } from '../../constants';
 import { ADCLambdaCABundleAspect } from '../../utils/adcCertBundleAspect';
 import { createLambdaLayer } from '../../utils/layers';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { mapStringToArchitecture } from '../../utils/apiFunction'
 
 export type SystemBannerConfiguration = {
     readonly text?: string;
@@ -285,6 +288,7 @@ export class RestApiStack extends Stack {
             },
             vpc: props.mlSpaceVPC,
             securityGroups: props.lambdaSecurityGroups,
+            architecture: mapStringToArchitecture(LAMBDA_CONFIGS.architecture),
         });
 
         this.mlspaceRequestAuthorizer = new RequestAuthorizer(this, 'MLSpaceAPIGWAuthorizer', {
@@ -343,3 +347,4 @@ export class RestApiStack extends Stack {
         this.mlSpaceRestApiRootResourceId = mlSpaceRestApi.restApiRootResourceId;
     }
 }
+

--- a/lib/stacks/infra/core.ts
+++ b/lib/stacks/infra/core.ts
@@ -54,9 +54,12 @@ import {
     RESOURCE_TERMINATION_INTERVAL,
     SYSTEM_TAG,
     USERS_TABLE_NAME,
+    LAMBDA_CONFIGS,
 } from '../../constants';
 import { ADCLambdaCABundleAspect } from '../../utils/adcCertBundleAspect';
 import { createLambdaLayer } from '../../utils/layers';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { mapStringToArchitecture } from '../../utils/apiFunction'
 
 export type CoreStackProps = {
     readonly lambdaSourcePath: string;
@@ -253,6 +256,7 @@ export class CoreStack extends Stack {
             layers: [notifierLambdaLayer.layerVersion],
             vpc: props.mlSpaceVPC,
             securityGroups: props.lambdaSecurityGroups,
+            architecture: mapStringToArchitecture(LAMBDA_CONFIGS.architecture),
         });
 
         s3NotificationLambda.addPermission('s3Notifier-invoke', {
@@ -291,6 +295,7 @@ export class CoreStack extends Stack {
             layers: [commonLambdaLayer.layerVersion],
             vpc: props.mlSpaceVPC,
             securityGroups: props.lambdaSecurityGroups,
+            architecture: mapStringToArchitecture(LAMBDA_CONFIGS.architecture),
         });
 
         const ruleName = 'mlspace-rule-terminate-resources';
@@ -453,6 +458,7 @@ export class CoreStack extends Stack {
             layers: [commonLambdaLayer.layerVersion],
             vpc: props.mlSpaceVPC,
             securityGroups: props.lambdaSecurityGroups,
+            architecture: mapStringToArchitecture(LAMBDA_CONFIGS.architecture),
         });
 
         // Event bridge rule for resource metadata capture

--- a/lib/utils/apiFunction.ts
+++ b/lib/utils/apiFunction.ts
@@ -36,7 +36,9 @@ import {
     RESOURCE_SCHEDULE_TABLE_NAME,
     SYSTEM_TAG,
     USERS_TABLE_NAME,
+    LAMBDA_CONFIGS,
 } from '../constants';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 
 export type MLSpacePythonLambdaFunction = {
     id?: string;
@@ -90,6 +92,7 @@ export function registerAPIEndpoint (
         layers,
         vpc,
         securityGroups,
+        architecture: mapStringToArchitecture(LAMBDA_CONFIGS.architecture),
     });
     const functionResource = getOrCreateResource(stack, api.root, funcDef.path.split('/'));
     functionResource.addMethod(funcDef.method, new LambdaIntegration(handler), {
@@ -117,3 +120,15 @@ function getOrCreateResource (stack: Stack, parentResource: IResource, path: str
     }
     return resource;
 }
+
+// Mapping string to Architecture enum
+export const mapStringToArchitecture = (arch: string): lambda.Architecture => {
+    switch (arch) {
+        case 'arm64':
+            return lambda.Architecture.ARM_64;
+        case 'x86_64':
+            return lambda.Architecture.X86_64;
+        default:
+            throw new Error(`Unsupported architecture: ${arch}`);
+    }
+};


### PR DESCRIPTION
*Issue #, if available: generated lambda functions were not working properly if the cdk was built on an arm64 instance.

*Description of changes: 

- lib/constants.ts - added support for the specification of the architecture of the containers being deployed, default is to x86_64
- lib/stacks/infra/core.ts - implemented config change using constants.ts to specify the architecture of the containers
- lib/utils/apiFunction.ts - added helper function to translate string LAMBDA_CONFIG.archicture to proper enumeration value and config change using constants.ts to specify the architecture of the containers
- lib/stacks/api/restApi.ts - config change using constants.ts to specify the architecture of the containers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
