### PR TITLE
[AIML-ADC-8090] Fix issue with fetching specific projects during report generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MLSpace
 
+[![Full Documentation](https://img.shields.io/badge/Full%20Documentation-blue?style=for-the-badge&logo=Vite&logoColor=white)](https://awslabs.github.io/mlspace/)
+
 ## Deployment Prerequisites
 
 ### Software

--- a/backend/test/data_access_objects/test_project.py
+++ b/backend/test/data_access_objects/test_project.py
@@ -140,7 +140,7 @@ class TestProjectDAO(TestCase):
 
     def test_get_all_projects(self):
         all_projects = self.project_dao.get_all()
-        assert len(all_projects) == 2
+        assert len(all_projects) == 1
 
     def test_get_all_projects_filtered(self):
         all_projects = self.project_dao.get_all(project_names=[self.UPDATE_PROJECT.name, self.DELETE_PROJECT.name])


### PR DESCRIPTION
*Issue #, if available:*
AIML-ADC-8090

*Description of changes:*
Updated `get_all` method in project dao to not short circuit if `include_suspended` was set to `True`. While generating reports we will always include suspended projects but the existing logic prevented us from only including specific projects in the report as the ddb scan was being executed without a filter. The updated body will apply a filter for `suspended = false` if `include_suspended` is `False` (default), it will then add an additional project filter if present, and will then execute the scan. The existing unit test was incorrectly asserting that `get_all` with no arguments returned 2 entries when the seeded projects include 1 suspended and 1 active project. Since `include_suspended` defaults to `False` that test should only expect a single matching project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
