### PR TITLE
Config merge bugfix

### DIFF
--- a/lib/utils/configTypes.ts
+++ b/lib/utils/configTypes.ts
@@ -220,10 +220,8 @@ export function generateConfig () {
         const fileConfig: MLSpaceConfig = JSON.parse(
             fs.readFileSync('lib/config.json').toString('utf8')
         );
-        _.merge(config, [fileConfig]);
+        _.merge(config, fileConfig);
     }
-
-    
 
     validateRequiredProperty(config.AWS_ACCOUNT, 'AWS_ACCOUNT');
     validateRequiredProperty(config.OIDC_URL, 'OIDC_URL');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* For the merge of the config.json file and constants.ts, the `fileConfig` variable shouldn't be in a list as this messes up how the value is parsed in the merge.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
