### PR TITLE
Validation requirements too restrctive

### DIFF
--- a/frontend/src/entities/jobs/hpo/create/training-definitions/training-job-definition.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/training-job-definition.tsx
@@ -104,7 +104,7 @@ const formSchema = z.object({
         )
         .superRefine(duplicateAttributeRefinement('ChannelName')),
     OutputDataConfig: z.object({
-        S3OutputPath: z.string().datasetPrefix(),
+        S3OutputPath: z.string().datasetUri(),
     }),
 });
 

--- a/frontend/src/entities/jobs/labeling/create/labeling-job-create.tsx
+++ b/frontend/src/entities/jobs/labeling/create/labeling-job-create.tsx
@@ -119,7 +119,7 @@ export function LabelingJobCreate () {
             OutputConfig: z.object({
                 S3OutputPath: z.string().min(1, {
                     message: 'Must enter output dataset.',
-                }).s3Prefix(),
+                }).datasetUri(),
             }),
             HumanTaskConfig: z.object({
                 NumberOfHumanWorkersPerDataObject: z

--- a/frontend/src/entities/jobs/training/create/training-job-create.tsx
+++ b/frontend/src/entities/jobs/training/create/training-job-create.tsx
@@ -258,7 +258,7 @@ export default function TrainingJobCreate () {
             })
         ),
         OutputDataConfig: z.object({
-            S3OutputPath: z.string().datasetPrefix(),
+            S3OutputPath: z.string().datasetUri(),
         }),
     });
 

--- a/frontend/src/entities/jobs/transform/create/transform-create.tsx
+++ b/frontend/src/entities/jobs/transform/create/transform-create.tsx
@@ -131,7 +131,7 @@ export function TransformCreate () {
         TransformOutput: z.object({
             Accept: z.string().max(256).optional(),
             AssembleWith: z.string().optional(),
-            S3OutputPath: z.string({ required_error: 'S3 output location is required' }).max(1024).s3Prefix(),
+            S3OutputPath: z.string({ required_error: 'S3 output location is required' }).max(1024).datasetUri(),
         }),
         TransformResources: z.object({
             InstanceCount: z.number().gte(1).lte(100),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The new Dataset improvements I added made the validation for output URIs overly restrictive. This was a worse user experience and made cloning Training/HPO jobs look broken.

I've also standardized validation on requiring output URIs to conform to Datasets URIs. The frontend UI components was already effectively doing this by forcing users to select a Dataset as the output so this isn't a departure from what was happening before the Dataset improvements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
