### PR TITLE
Fixed error when no query string parameters are sent when listing Dataset files

### DIFF
--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -232,7 +232,7 @@ def list_resources(event, context):
 @api_wrapper
 def list_files(event, context):
     env_variables = get_environment_variables()
-    query_string_parameters = event.get("queryStringParameters", {})
+    query_string_parameters = event.get("queryStringParameters") or {}
 
     # map query parameters keys to api parameter names
     query_string_parameters = rename_dict_keys(

--- a/backend/test/dataset/test_list_dataset_files.py
+++ b/backend/test/dataset/test_list_dataset_files.py
@@ -210,6 +210,28 @@ def test_list_dataset_files_empty(mock_s3, mock_dataset_dao, mock_global_dataset
 
 @mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
 @mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
+def test_list_dataset_files_no_querystring(mock_s3, mock_dataset_dao, mock_global_dataset):
+    mock_dataset_dao.get.return_value = mock_global_dataset
+    mock_s3.list_objects_v2.return_value = {
+        "Prefix": "global/datasets/example_dataset/",
+        "MaxKeys": 1000,
+    }
+
+    expected_response = generate_html_response(
+        200,
+        {
+            "pageSize": 1000,
+            "prefix": "global/datasets/example_dataset/",
+            "bucket": "mlspace-data-bucket",
+            "contents": [],
+        },
+    )
+
+    assert lambda_handler(build_mock_event(mock_global_dataset, None), mock_context) == expected_response
+
+
+@mock.patch("ml_space_lambda.dataset.lambda_functions.dataset_dao")
+@mock.patch("ml_space_lambda.dataset.lambda_functions.s3")
 def test_list_dataset_files_client_error(mock_s3, mock_dataset_dao, mock_global_dataset):
     error_msg = {
         "Error": {"Code": "ThrottlingException", "Message": "Dummy error message."},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

An error would occur when fetching the files for a Dataset with no query string parameters present. This happened because APIGW sets the `queryStringParameters` property on the `event` parameter to `None` instead of just not setting it. This causes `event.get("queryStringParameters", {})` to return `None` instead of `{}`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
