### PR TITLE
add username normalization in frontend and backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   rev: 5.13.2
   hooks:
     - id: isort
-      args: ["--profile", "black", "--check-only", "./backend"]
+      args: ["--profile", "black", "./backend"]
 
 - repo: https://github.com/pycqa/flake8
   rev: 7.0.0

--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import time
+import urllib
 from typing import Any, Dict, Optional, Tuple
 
 import jwt
@@ -100,7 +101,13 @@ def lambda_handler(event, context):
             "context": response_context,
         }
 
-    username = token_info["preferred_username"]
+    username = (
+        urllib.parse.unquote(token_info["preferred_username"])
+        .replace(",", "-")
+        .replace(".", "-")
+        .replace("=", "-")
+        .replace(" ", "-")
+    )
     requested_resource = event["resource"]
     path_params = event["pathParameters"]
     request_method = event["httpMethod"]

--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -101,13 +101,7 @@ def lambda_handler(event, context):
             "context": response_context,
         }
 
-    username = (
-        urllib.parse.unquote(token_info["preferred_username"])
-        .replace(",", "-")
-        .replace(".", "-")
-        .replace("=", "-")
-        .replace(" ", "-")
-    )
+    username = urllib.parse.unquote(token_info["preferred_username"]).replace(",", "-").replace("=", "-").replace(" ", "-")
     requested_resource = event["resource"]
     path_params = event["pathParameters"]
     request_method = event["httpMethod"]

--- a/backend/src/ml_space_lambda/project/lambda_functions.py
+++ b/backend/src/ml_space_lambda/project/lambda_functions.py
@@ -17,6 +17,7 @@
 import json
 import logging
 import re
+import urllib
 from collections import Counter
 from typing import List, Optional
 
@@ -202,7 +203,7 @@ def add_users(event, context):
 @api_wrapper
 def remove_user(event, context):
     project_name = event["pathParameters"]["projectName"]
-    username = event["pathParameters"]["username"]
+    username = urllib.parse.unquote(event["pathParameters"]["username"])
 
     env_variables = get_environment_variables()
 
@@ -435,7 +436,7 @@ def delete(event, context):
 @api_wrapper
 def update_project_user(event, context):
     project_name = event["pathParameters"]["projectName"]
-    username = event["pathParameters"]["username"]
+    username = urllib.parse.unquote(event["pathParameters"]["username"])
     updates = json.loads(event["body"])
 
     project_user = project_user_dao.get(project_name, username)

--- a/frontend/src/config/oidc.config.ts
+++ b/frontend/src/config/oidc.config.ts
@@ -31,7 +31,7 @@ export const oidcConfig: AuthProviderProps = {
             document.title,
             `${window.location.pathname}${window.location.hash}`
         );
-        user!.profile.preferred_username = user!.profile.preferred_username!.replace(/,|\.|=| /gi, '-');
+        user!.profile.preferred_username = user!.profile.preferred_username!.replace(/,|=| /gi, '-');
         const mlspaceUser = {
             username: user!.profile.preferred_username,
             email: user!.profile.email,

--- a/frontend/src/config/oidc.config.ts
+++ b/frontend/src/config/oidc.config.ts
@@ -31,6 +31,7 @@ export const oidcConfig: AuthProviderProps = {
             document.title,
             `${window.location.pathname}${window.location.hash}`
         );
+        user!.profile.preferred_username = user!.profile.preferred_username!.replace(/,|\.|=| /gi, '-');
         const mlspaceUser = {
             username: user!.profile.preferred_username,
             email: user!.profile.email,

--- a/frontend/src/entities/user/user.reducer.ts
+++ b/frontend/src/entities/user/user.reducer.ts
@@ -65,7 +65,7 @@ export const addUsersToProject = createAsyncThunk(
 export const removeUserFromProject = createAsyncThunk(
     'user/remove_user_from_project',
     async (data: IProjectUser) => {
-        const requestUrl = `/project/${data.project}/users/${data.user}`;
+        const requestUrl = `/project/${data.project}/users/${encodeURIComponent(data.user || '')}`;
         return axios.delete(requestUrl);
     }
 );
@@ -73,7 +73,7 @@ export const removeUserFromProject = createAsyncThunk(
 export const updateUsersInProject = createAsyncThunk(
     'user/update_user_role',
     async (projectUser: IProjectUser) => {
-        const requestUrl = `/project/${projectUser.project}/users/${projectUser.user}`;
+        const requestUrl = `/project/${projectUser.project}/users/${encodeURIComponent(projectUser.user || '')}`;
         return axios.put<IProjectUser>(requestUrl, projectUser);
     }
 );
@@ -81,7 +81,7 @@ export const updateUsersInProject = createAsyncThunk(
 export const updateUser = createAsyncThunk(
     'user/update_user',
     async (user: IUser) => {
-        const requestUrl = `/user/${user.username}`;
+        const requestUrl = `/user/${encodeURIComponent(user.username || '')}`;
         return await axios.put<IUser>(requestUrl, user);
     }
 );


### PR DESCRIPTION
*Issue #, if available:* AIML-ADC-8218

*Description of changes:*
- Add username normalization in frontend and backend by removing , . = and spaces. 

This allows usernames with special characters like from a DN. Example: `CN=Jeff Smith,OU=Sales,DC=Fabrikam,DC=COM`


User can still create datasets, project, labeling jobs, etc.
![Screenshot 2024-04-19 at 4 23 29 PM](https://github.com/awslabs/mlspace/assets/28429388/06557b65-7c07-45a4-a5d9-745773f094a3)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
