### PR TITLE
Resolves eslint issue

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -47,6 +47,12 @@
         "react-hooks/exhaustive-deps": "error",
         "react/prop-types": "off"
     },
+    "overrides": [{
+        "files": ["src/shared/validation/helpers/uri.ts"],
+        "rules": {
+            "@typescript-eslint/consistent-type-definitions": "off"
+        }
+    }],
     "env": {
         "browser": true,
         "es2021": true

--- a/frontend/src/shared/validation/helpers/uri.ts
+++ b/frontend/src/shared/validation/helpers/uri.ts
@@ -17,7 +17,6 @@ import { z, ZodString } from 'zod';
 import { errorUtil } from 'zod/lib/helpers/errorUtil';
 
 declare module 'zod' {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
     interface ZodString {
         s3Uri(message?: errorUtil.ErrMessage): ZodString;
         s3Prefix(message?: errorUtil.ErrMessage): ZodString;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We're extending the external `ZodString` prototype object which forces us to use a syntax that we don't want to use anywhere else in our project. This has caused an issue where eslint fails to pass occasionally even though we have an `eslint-disable-next-line` comment. This fix moves disabling the rule to the `.eslintrc` which resolves the failure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
