### PR TITLE
Display DatasetSelector warning when file(s) don't exist.

### DIFF
--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -237,7 +237,7 @@ def list_files(event, context):
     # map query parameters keys to api parameter names
     query_string_parameters = rename_dict_keys(
         query_string_parameters,
-        {"nextToken": "ContinuationToken", "pageSize": "MaxKeys", "prefix": "Prefix"},
+        {"nextToken": "ContinuationToken", "pageSize": "MaxKeys", "prefix": "Prefix", "delimiter": "Delimiter"},
     )
 
     dataset_prefix = get_dataset_prefix(event["pathParameters"]["scope"], event["pathParameters"]["datasetName"])
@@ -252,7 +252,7 @@ def list_files(event, context):
     }
 
     # don't allow arbitrary query string parameters added to the query_parameters dict
-    allowed_query_string_parameters = ["MaxKeys", "ContinuationToken"]
+    allowed_query_string_parameters = ["MaxKeys", "ContinuationToken", "Delimiter"]
     for key in filter_dict_by_keys(query_string_parameters, allowed_query_string_parameters):
         query_parameters[key] = query_string_parameters[key]
 

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/input-data-configuration.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/input-data-configuration.tsx
@@ -42,6 +42,7 @@ import { enumToOptions } from '../../../../../shared/util/enum-utils';
 import { createInputDataConfig } from '../../../create.functions';
 import DatasetResourceSelector from '../../../../../modules/dataset/dataset-selector';
 import { datasetFromS3Uri } from '../../../../../shared/util/dataset-utils';
+import { DatasetResourceSelectorSelectableItems } from '../../../../../modules/dataset/dataset-selector.types';
 
 export type InputDataConfigurationProps = FormProps<(InputDataConfig & DatasetExtension)[]>;
 
@@ -150,6 +151,13 @@ export function Channel (props: ChannelProps) {
      *   .Dataset.Location
      *   .DataSource.S3DataSource.S3Uri
      */
+
+    let selectableItemsTypes: DatasetResourceSelectorSelectableItems[] = ['prefixes', 'objects'];
+    if (item.DataSource.S3DataSource?.S3DataType === S3DataType.S3Prefix) {
+        selectableItemsTypes = ['prefixes'];
+    } else if ([S3DataType.AugmentedManifestFile, S3DataType.ManifestFile].map(String).includes(item.DataSource.S3DataSource?.S3DataType ?? '')) {
+        selectableItemsTypes = ['objects'];
+    }
 
     return (
         <SpaceBetween direction='vertical' size='m'>
@@ -261,7 +269,7 @@ export function Channel (props: ChannelProps) {
             </Grid>
             <DatasetResourceSelector
                 fieldLabel={'S3 Location'}
-                selectableItemsTypes={['objects']}
+                selectableItemsTypes={selectableItemsTypes}
                 onChange={({detail}) => {
                     setFields({
                         'DataSource.S3DataSource.S3Uri': detail.resource,
@@ -272,7 +280,8 @@ export function Channel (props: ChannelProps) {
                 }}
                 inputInvalid={!!formErrors?.DataSource?.S3DataSource?.S3Uri}
                 fieldErrorText={formErrors?.DataSource?.S3DataSource?.S3Uri}
-                resource={item.DataSource.S3DataSource?.S3Uri || ''}
+                resource={item.DataSource.S3DataSource?.S3Uri ?? ''}
+                alertOnEmpty={true}
             />
         </SpaceBetween>
     );

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/input-data-configuration.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/input-data-configuration.tsx
@@ -153,10 +153,13 @@ export function Channel (props: ChannelProps) {
      */
 
     let selectableItemsTypes: DatasetResourceSelectorSelectableItems[] = ['prefixes', 'objects'];
-    if (item.DataSource.S3DataSource?.S3DataType === S3DataType.S3Prefix) {
-        selectableItemsTypes = ['prefixes'];
-    } else if ([S3DataType.AugmentedManifestFile, S3DataType.ManifestFile].map(String).includes(item.DataSource.S3DataSource?.S3DataType ?? '')) {
-        selectableItemsTypes = ['objects'];
+    switch (item.DataSource.S3DataSource?.S3DataType) {
+        case S3DataType.S3Prefix:
+            selectableItemsTypes = ['prefixes'];
+            break;
+        case S3DataType.ManifestFile:
+        case S3DataType.AugmentedManifestFile:
+            selectableItemsTypes = ['objects'];    
     }
 
     return (

--- a/frontend/src/entities/jobs/transform/create/transform-create.tsx
+++ b/frontend/src/entities/jobs/transform/create/transform-create.tsx
@@ -30,7 +30,7 @@ import {
     SelectProps,
     ContentLayout,
 } from '@cloudscape-design/components';
-import { ITransform, defaultValue } from '../../../../shared/model/transform.model';
+import { AssembleWith, BatchStrategy, CompressionType, ITransform, S3DataType, SplitType, defaultValue } from '../../../../shared/model/transform.model';
 import { useAppDispatch, useAppSelector } from '../../../../config/store';
 import { setBreadcrumbs } from '../../../../shared/layout/navigation/navigation.reducer';
 import NotificationService from '../../../../shared/layout/notification/notification.service';
@@ -148,9 +148,9 @@ export function TransformCreate () {
     });
 
     let selectableItemsTypes: DatasetResourceSelectorSelectableItems[] = ['prefixes', 'objects'];
-    if (state.form.TransformInput.DataSource.S3DataSource.S3DataType === 'S3Prefix') {
+    if (state.form.TransformInput.DataSource.S3DataSource.S3DataType === S3DataType.S3Prefix) {
         selectableItemsTypes = ['prefixes'];
-    } else if (state.form.TransformInput.DataSource.S3DataSource.S3DataType === 'ManifestFile') {
+    } else if (state.form.TransformInput.DataSource.S3DataSource.S3DataType === S3DataType.ManifestFile) {
         selectableItemsTypes = ['objects'];
     }
 
@@ -163,18 +163,18 @@ export function TransformCreate () {
             ])
         );
         setS3DataTypes([
-            { value: 'S3Prefix', label: 'S3Prefix' },
-            { value: 'ManifestFile', label: 'ManifestFile' },
+            { value: S3DataType.S3Prefix, label: S3DataType.S3Prefix },
+            { value: S3DataType.ManifestFile, label: S3DataType.ManifestFile },
         ]);
         setSplitTypes([
-            { value: 'None', label: 'None' },
-            { value: 'Line', label: 'Line' },
-            { value: 'RecordIO', label: 'RecordIO' },
-            { value: 'TFRecord', label: 'TFRecord' },
+            { value: SplitType.None, label: SplitType.None },
+            { value: SplitType.Line, label: SplitType.Line },
+            { value: SplitType.RecordIO, label: SplitType.RecordIO },
+            { value: SplitType.TFRecord, label: SplitType.TFRecord },
         ]);
         setCompressionTypes([
-            { value: 'None', label: 'None' },
-            { value: 'Gzip', label: 'Gzip' },
+            { value: CompressionType.None, label: CompressionType.None },
+            { value: CompressionType.Gzip, label: CompressionType.Gzip },
         ]);
         setContentTypes([
             { value: 'application/x-image', label: 'application/x-image' },
@@ -182,13 +182,13 @@ export function TransformCreate () {
             { value: 'text/csv', label: 'text/csv' },
         ]);
         setAssembleWithTypes([
-            { value: 'None', label: 'None' },
-            { value: 'Line', label: 'Line' },
+            { value: AssembleWith.None, label: AssembleWith.None },
+            { value: AssembleWith.Line, label: AssembleWith.Line },
         ]);
         setBatchStrategies([
             { value: '', label: '' },
-            { value: 'SingleRecord', label: 'SingleRecord' },
-            { value: 'MultiRecord', label: 'MultiRecord' },
+            { value: BatchStrategy.SingleRecord, label: BatchStrategy.SingleRecord },
+            { value: BatchStrategy.MultiRecord, label: BatchStrategy.MultiRecord },
         ]);
         setJoinSources([
             { value: 'None', label: 'None - Use output job only' },

--- a/frontend/src/entities/jobs/transform/create/transform-create.tsx
+++ b/frontend/src/entities/jobs/transform/create/transform-create.tsx
@@ -61,6 +61,7 @@ import {
 import { tryCreateDataset } from '../../../dataset/dataset.service';
 import DatasetResourceSelector from '../../../../modules/dataset/dataset-selector';
 import { datasetFromS3Uri } from '../../../../shared/util/dataset-utils';
+import { DatasetResourceSelectorSelectableItems } from '../../../../modules/dataset/dataset-selector.types';
 
 export function TransformCreate () {
     const [s3DataTypes, setS3DataTypes] = useState([] as SelectProps.Option[]);
@@ -145,6 +146,13 @@ export function TransformCreate () {
         touched: {},
         formSubmitting: false as boolean,
     });
+
+    let selectableItemsTypes: DatasetResourceSelectorSelectableItems[] = ['prefixes', 'objects'];
+    if (state.form.TransformInput.DataSource.S3DataSource.S3DataType === 'S3Prefix') {
+        selectableItemsTypes = ['prefixes'];
+    } else if (state.form.TransformInput.DataSource.S3DataSource.S3DataType === 'ManifestFile') {
+        selectableItemsTypes = ['objects'];
+    }
 
     useEffect(() => {
         dispatch(
@@ -636,7 +644,7 @@ export function TransformCreate () {
                             </Grid>
                             <DatasetResourceSelector
                                 fieldLabel={'S3 Location'}
-                                selectableItemsTypes={['objects']}
+                                selectableItemsTypes={selectableItemsTypes}
                                 onChange={({detail}) => {
                                     setFields({
                                         'TransformInput.DataSource.S3DataSource.S3Uri': detail.resource,
@@ -648,6 +656,7 @@ export function TransformCreate () {
                                 inputInvalid={!!errors?.TransformInput?.DataSource?.S3DataSource?.S3Uri}
                                 fieldErrorText={errors?.TransformInput?.DataSource?.S3DataSource?.S3Uri}
                                 resource={state.form?.TransformInput?.DataSource?.S3DataSource?.S3Uri || ''}
+                                alertOnEmpty={true}
                             />
                         </SpaceBetween>
                     </Container>

--- a/frontend/src/modules/dataset/dataset-browser.reducer.tsx
+++ b/frontend/src/modules/dataset/dataset-browser.reducer.tsx
@@ -29,7 +29,8 @@ import { DatasetBrowserManageMode } from './dataset-browser.types';
  */
 export type DatasetServerRequestProps = ServerRequestProps & {
     datasetContext: Partial<DatasetContext>,
-    username?: string
+    username?: string,
+    delimiter?: string
 };
 
 /**
@@ -175,16 +176,11 @@ export const getDatasetContents = createAsyncThunk(
 
         const searchParams = new URLSearchParams();
 
-        if (props.nextToken) {
-            searchParams.set('nextToken', props.nextToken);
-        }
-
-        if (props.pageSize) {
-            searchParams.set('pageSize', String(props.pageSize));
-        }
-
-        if (props.projectName) {
-            searchParams.set('projectName', props.projectName);
+        const queryStringParameters = ['nextToken', 'pageSize', 'projectName', 'delimiter'];
+        for (const key of queryStringParameters) {
+            if (props[key] !== undefined) {
+                searchParams.set(key, String(props[key]));    
+            }
         }
 
         if (datasetContext?.location) {

--- a/frontend/src/modules/dataset/dataset-selector.reducer.tsx
+++ b/frontend/src/modules/dataset/dataset-selector.reducer.tsx
@@ -18,6 +18,7 @@ export type DatasetResourceSelectorState = {
     resource?: string;
     selected?: string;
     newDatasetUri?: string;
+    isEmpty: boolean;
 };
 
 export enum DatasetResourceSelectorMode {

--- a/frontend/src/modules/dataset/dataset-selector.tsx
+++ b/frontend/src/modules/dataset/dataset-selector.tsx
@@ -59,19 +59,19 @@ export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
                 datasetContext,
                 delimiter: ''
             })).then((response) => {
-                let scope = String(datasetContext.type);
+                let scope = '';
                 switch (datasetContext.type) {
                     case DatasetType.PRIVATE:
-                        scope += `/${username}`;
+                        scope = `${username}`;
                         break;
                     case DatasetType.PROJECT:
-                        scope += `/${projectName}`;
+                        scope = `${projectName}`;
                         break;
                 }
     
                 let isEmpty = true;
                 if (isFulfilled(response)) {
-                    const location = [scope, 'datasets', datasetContext.name, `${datasetContext.location}`].filter(Boolean).join('/');
+                    const location = [datasetContext.type, scope, 'datasets', datasetContext.name, datasetContext.location].filter(Boolean).join('/');
                     // check if any resource is an exact match or has a matching prefix
                     isEmpty = !response.payload.data.contents.find((resource) => {
                         if (resource.type !== 'object') {
@@ -117,6 +117,14 @@ export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
         }
     };
 
+    const notFoundTypes: string[] = [];
+    if (isSelectingObject) {
+        notFoundTypes.push('name');
+    }
+    if (isSelectingPrefixes) {
+        notFoundTypes.push('prefix');
+    }
+
     return (
         <>
             <FormField {...fieldProps}>
@@ -125,14 +133,8 @@ export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
                         <Input placeholder={s3UriPlaceholder} {...inputProps} type='search'></Input>
                         <Condition condition={!!props.alertOnEmpty && state.isEmpty}>
                             <Alert statusIconAriaLabel='Warning' type='warning'>
-                                <Condition condition={isSelectingObject && isSelectingPrefixes}>
-                                        No file found with this name and no files found with this prefix.
-                                </Condition>
-                                <Condition condition={isSelectingObject && !isSelectingPrefixes}>
-                                        No file found with this name.
-                                </Condition>
-                                <Condition condition={!isSelectingObject && isSelectingPrefixes}>
-                                        No files found with this prefix.
+                                <Condition condition={notFoundTypes.length > 0}>
+                                        No file(s) found with this {notFoundTypes.join(' or ')}.
                                 </Condition>
                             </Alert>
                         </Condition>

--- a/frontend/src/modules/dataset/dataset-selector.tsx
+++ b/frontend/src/modules/dataset/dataset-selector.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 import React, { useCallback, useEffect } from 'react';
-import { Button, FormField, Grid, Input, SpaceBetween} from '@cloudscape-design/components';
+import { Alert, Button, FormField, FormFieldProps, Grid, Input, SpaceBetween} from '@cloudscape-design/components';
 import Condition from '../condition';
 import { DatasetResourceSelectorProps } from './dataset-selector.types';
 import { DatasetResourceSelectorMode, datasetResourceSelectorReducer } from './dataset-selector.reducer';
@@ -25,18 +25,70 @@ import { useUsername } from '../../shared/util/auth-utils';
 import { modalPropertiesForBrowse, modalPropertiesForCreate } from './dataset-selector.utils';
 import { DatasetInlineCreate } from './dataset-inline-create';
 import { extractPrefixedType } from '../../shared/util/types';
+import { useAppDispatch } from '../../config/store';
+import { getDatasetContents } from './dataset-browser.reducer';
+import { datasetFromS3Uri } from '../../shared/util/dataset-utils';
+import { isFulfilled } from '@reduxjs/toolkit';
+import { debounce } from 'lodash';
+import { DatasetType } from '../../shared/model';
 
 export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
     const username = useUsername();
     const { projectName = '' } = useParams();
     const isSelectingObject = (props.selectableItemsTypes || []).includes('objects');
+    const isSelectingPrefixes = (props.selectableItemsTypes || []).includes('prefixes');
     const s3UriPlaceholder = isSelectingObject ? 's3://bucket/prefix/object' : 's3://bucket/prefix/';
+    const dispatch = useAppDispatch();
 
     const [state, setState] = React.useReducer(datasetResourceSelectorReducer, {
         mode: DatasetResourceSelectorMode.None,
         resource: props.resource,
         selected: undefined,
+        isEmpty: false,
     });
+
+    // disable since debounce() interferes with the linter tracking dependencies
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const updateIsEmpty = useCallback(debounce((s3Uri: string) => {
+        const datasetContext = datasetFromS3Uri(s3Uri);
+
+        if (datasetContext?.name) {
+            dispatch(getDatasetContents({
+                username,
+                projectName,
+                datasetContext,
+                delimiter: ''
+            })).then((response) => {
+                let scope = String(datasetContext.type);
+                switch (datasetContext.type) {
+                    case DatasetType.PRIVATE:
+                        scope += `/${username}`;
+                        break;
+                    case DatasetType.PROJECT:
+                        scope += `/${projectName}`;
+                        break;
+                }
+    
+                let isEmpty = true;
+                if (isFulfilled(response)) {
+                    const location = [scope, 'datasets', datasetContext.name, `${datasetContext.location}`].filter(Boolean).join('/');
+                    // check if any resource is an exact match or has a matching prefix
+                    isEmpty = !response.payload.data.contents.find((resource) => {
+                        if (resource.type !== 'object') {
+                            return false;
+                        }
+
+                        return (isSelectingObject && resource.key === location) ||
+                            (isSelectingPrefixes && resource.key.startsWith(`${location}/`.replace(/\/+$/, '/')));
+                    });
+                }
+
+                setState({
+                    isEmpty
+                });
+            });                
+        }
+    }, 300), [dispatch, username, projectName, isSelectingObject, isSelectingPrefixes]);
 
     // if resource changes reset to defaults
     useEffect(() => {
@@ -45,9 +97,13 @@ export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
             resource: props.resource,
             selected: undefined
         });
-    }, [props.resource]);
 
-    const fieldProps = extractPrefixedType(props, 'field');
+        if (props.alertOnEmpty && props.resource) {
+            updateIsEmpty(props.resource);
+        }
+    }, [props.resource, props.alertOnEmpty, updateIsEmpty, props.selectableItemsTypes]);
+
+    const fieldProps: FormFieldProps = extractPrefixedType(props, 'field');
     const inputProps = {
         ...extractPrefixedType(props, 'input'),
         value: props.resource,
@@ -65,7 +121,22 @@ export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
         <>
             <FormField {...fieldProps}>
                 <Grid gridDefinition={[{colspan: 6}, {colspan: 6}]}>
-                    <Input placeholder={s3UriPlaceholder} {...inputProps} type='search'></Input>
+                    <SpaceBetween direction='vertical' size='xs'>
+                        <Input placeholder={s3UriPlaceholder} {...inputProps} type='search'></Input>
+                        <Condition condition={!!props.alertOnEmpty && state.isEmpty}>
+                            <Alert statusIconAriaLabel='Warning' type='warning'>
+                                <Condition condition={isSelectingObject && isSelectingPrefixes}>
+                                        No file found with this name and no files found with this prefix.
+                                </Condition>
+                                <Condition condition={isSelectingObject && !isSelectingPrefixes}>
+                                        No file found with this name.
+                                </Condition>
+                                <Condition condition={!isSelectingObject && isSelectingPrefixes}>
+                                        No files found with this prefix.
+                                </Condition>
+                            </Alert>
+                        </Condition>
+                    </SpaceBetween>
                     <SpaceBetween direction='horizontal' size='m'>
                         <Button onClick={() => {
                             setState({

--- a/frontend/src/modules/dataset/dataset-selector.types.ts
+++ b/frontend/src/modules/dataset/dataset-selector.types.ts
@@ -19,7 +19,7 @@ import { IDataset } from '../../shared/model';
 import { DatasetResource } from './dataset-browser.reducer';
 import { PrefixedType } from '../../shared/util/types';
 
-type DatasetResourceSelectorSelectableItems = 'prefixes' | 'objects';
+export type DatasetResourceSelectorSelectableItems = 'prefixes' | 'objects';
 
 type DatasetResourceSelectorChangeDetail = {
     resource: string;
@@ -61,4 +61,8 @@ export type DatasetResourceSelectorProps = {
      * Should the create button be shown.
      */
     showCreateButton?: boolean;
+    /**
+     * Should an alet be displayed if the file does not exist or prefix is empty.
+     */
+    alertOnEmpty?: boolean;
 } & PrefixedType<Omit<InputProps, 'onChange' | 'selectableItemsTypes' | 'viewHref' | 'value'>, 'input'> & PrefixedType<FormFieldProps, 'field'>;

--- a/frontend/src/shared/model/transform.model.ts
+++ b/frontend/src/shared/model/transform.model.ts
@@ -16,9 +16,36 @@
 
 import { JobStatus } from '../../entities/jobs/job.model';
 
+export enum CompressionType {
+    None = 'None',
+    Gzip = 'Gzip',
+}
+
+export enum S3DataType {
+    ManifestFile = 'ManifestFile',
+    S3Prefix = 'S3Prefix',
+}
+
+export enum SplitType {
+    None = 'None',
+    Line = 'Line',
+    RecordIO = 'RecordIO',
+    TFRecord = 'TFRecord',
+}
+
+export enum AssembleWith {
+    None = 'None',
+    Line = 'Line',
+}
+
+export enum BatchStrategy {
+    MultiRecord = 'MultiRecord',
+    SingleRecord = 'SingleRecord',
+}
+
 export type ITransform = {
     AutoMLJobArn?: string;
-    BatchStrategy?: string;
+    BatchStrategy?: BatchStrategy;
     CreationTime?: string;
     DataCaptureConfig?: {
         DestinationS3Uri?: string;
@@ -47,22 +74,22 @@ export type ITransform = {
     ModelName?: string;
     TransformEndTime?: string;
     TransformInput: {
-        CompressionType?: string;
+        CompressionType?: CompressionType;
         ContentType?: string;
         DataSource: {
             S3DataSource: {
-                S3DataType?: string;
+                S3DataType?: S3DataType;
                 S3Uri: string;
             };
         };
-        SplitType?: string;
+        SplitType?: SplitType;
     };
     TransformJobArn?: string;
     TransformJobName?: string;
     TransformJobStatus?: JobStatus;
     TransformOutput?: {
         Accept?: string;
-        AssembleWith?: string;
+        AssembleWith?: AssembleWith;
         KmsKeyId?: string;
         S3OutputPath?: string;
     };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


**Changes**
- (frontend) Selectable types for the DatasetSelector is now tied to the S3 data type. Selecting `S3Prefix` will constraint the DatasetSelector to prefixes whereas `ManifestFile` or `AugmentedManifestFile` will force object selection.

- (frontend) When the `DatasetSelector` is used to select a file or prefix from a Dataset we know that a user wants to select a file or files respectively. This adds a warning if you're selecting a file and it does not exist or a prefix and no files exist under that prefix. <br /> <br /> ![Screenshot 2024-04-24 at 14 09 32](https://github.com/awslabs/mlspace/assets/14645/3b9f639a-e872-41b0-855f-053a5e588f7c)

- (backend) Updated Dataset list_files lambda to allow defining the s3 delimiter via query string parameter. By default `/` is used so only files/prefixes that are direct descendants of the prefix are returned. The change allows querying for any file starting with a prefix no matter how deeply it is nested.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
