### PR TITLE
Fix regression when creating training jobs with built-in algorithms without specifying custom metrics

### DIFF
--- a/backend/src/ml_space_lambda/utils/image_uri_utils.py
+++ b/backend/src/ml_space_lambda/utils/image_uri_utils.py
@@ -53,7 +53,8 @@ def delete_metric_definition_for_builtin_algorithms(algorithm_specifications) ->
         retrieve(
             image_components["framework"], image_components["region"], version=image_components["version"], image_scope=None
         )
-        del algorithm_specifications["MetricDefinitions"]
+        if "MetricDefinitions" in algorithm_specifications:
+            del algorithm_specifications["MetricDefinitions"]
         return True
     except IOError:
         # An exception occurs if the image/framework is not a detected built-in


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This PR addresses a recently introduced issue related to creating training jobs with built-in algorithms. When a training job is created from the MLSpace UI the metrics definitions are not included when a built-in algorithm is used. A [recent change](https://github.com/awslabs/mlspace/pull/52) was made to gracefully handle cases where a user did override the metrics definitions for a built in algorithm but the way that change was implemented prevented users from submitting a training job without setting something in the metrics override.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
