### PR TITLE
Fix issue where the incorrect S3 path was being used when creating models from training jobs

### DIFF
--- a/frontend/src/entities/jobs/training/training-job.actions.tsx
+++ b/frontend/src/entities/jobs/training/training-job.actions.tsx
@@ -31,7 +31,7 @@ export const createModelFromTrainingJob = (trainingJob : ITrainingJob, navigate:
     presetModel.Image =
         trainingJob.AlgorithmSpecification?.TrainingImage;
     presetModel.ModelDataUrl =
-        trainingJob.OutputDataConfig?.S3OutputPath;
+        trainingJob.ModelArtifacts?.S3ModelArtifacts;
     navigate(`/project/${projectName}/model/create`, {
         state: {
             presetModel: presetModel,


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

There was an issue when using the `Create Model` button on the training job details page where the resulting model form would have a prefilled model artifacts path that matched the training job output configuration path as opposed to the fully qualified model artifact. This PR updates the value sent to the create model form to be the actual artifact path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
