### PR TITLE
[AIML-ADC-8258] Add automatic deployment to demo environment

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy Demo
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  CheckPendingWorkflow:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ahmadnassri/action-workflow-queue@v1
+      with:
+        delay: 300000
+        timeout: 7200000
+
+  DeployMLSpace:
+    needs: CheckPendingWorkflow
+    environment: demo
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/GithubAction-AssumeRoleWithAction
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          role-duration-seconds: 7200
+
+      - name: Create config.json
+        id: create-json
+        uses: jsdaniell/create-json@v1.2.3
+        with:
+          name: "config.json"
+          json: |
+            {
+              "AWS_ACCOUNT": "${{ secrets.AWS_ACCOUNT }}",
+              "AWS_REGION": "${{ secrets.AWS_REGION }}",
+              "OIDC_URL": "${{ secrets.OIDC_URL }}",
+              "OIDC_CLIENT_NAME": "${{ secrets.OIDC_CLIENT_NAME }}",
+              "KEY_MANAGER_ROLE_NAME": "${{ secrets.KEY_MANAGER_ROLE_NAME }}"
+            }
+          dir: './lib/'
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: |
+          npm install
+
+      - name: Install CDK dependencies
+        run: |
+          npm install
+
+      - name: Deploy CDK
+        run: |
+          npm install -g aws-cdk
+          cdk deploy --require-approval never --all

--- a/lib/utils/layers.ts
+++ b/lib/utils/layers.ts
@@ -111,14 +111,16 @@ export class LambdaLayer extends Construct {
         cpSync(layerDir, buildDir, { recursive: true });
 
         // actually do the bundling
-        const code = bundleAction();
+        try {
+            const code = bundleAction();
 
-        // cleanup
-        if (existsSync(buildDir)) {
-            rmdirSync(buildDir, { recursive: true, });
+            return code;
+        } finally {
+            // cleanup
+            if (existsSync(buildDir)) {
+                rmdirSync(buildDir, { recursive: true, });
+            }
         }
-
-        return code;
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* AIML-ADC-8258

*Description of changes:*
Since migrating to github we don't have an environment always up-to-date with the latest revision of `main`. This adds a workflow that deploys to a demo environment automatically anytime code is pushed/merged into `main`. Currently it is deploying to my development environment but that is configurable through the `demo` environment secrets.

This requires that the target environment has a role named `GithubAction-AssumeRoleWithAction` that can assume `cdk-hnb659fds-deploy-role*`, `cdk-hnb659fds-file-publishing-role*`, `cdk-hnb659fds-image-publishing-role*`, `cdk-hnb659fds-lookup-role*`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
