### PR TITLE
Add missing spaceing between action buttons

### DIFF
--- a/frontend/src/entities/notebook/detail/notebook-detail.tsx
+++ b/frontend/src/entities/notebook/detail/notebook-detail.tsx
@@ -172,7 +172,7 @@ function NotebookDetail () {
                 <Header
                     variant='h1'
                     actions={
-                        <>
+                        <SpaceBetween direction='horizontal' size='xs'>
                             <Button
                                 data-cy='notebook-delete'
                                 disabled={!ownerOrPrivileged || !notebookStopped}
@@ -284,7 +284,7 @@ function NotebookDetail () {
                             >
                                 Open JupyterLab
                             </Button>
-                        </>
+                        </SpaceBetween>
                     }
                 >
                     {notebook.NotebookInstanceName}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The notebook detail page was missing spacing between the action buttons.

Original:
![Screenshot 2024-05-02 at 14 36 57](https://github.com/awslabs/mlspace/assets/14645/d6742640-a91c-41b1-90f2-aaf2102cae47)

After:
![Screenshot 2024-05-02 at 14 36 37](https://github.com/awslabs/mlspace/assets/14645/e8bc58ef-0f5b-4999-a302-0e5aa0dbae3d)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
