### PR TITLE
make dataset table use serverFetch and proper loading action

### DIFF
--- a/frontend/src/entities/dataset/dataset.actions.tsx
+++ b/frontend/src/entities/dataset/dataset.actions.tsx
@@ -24,7 +24,7 @@ import {
     deleteFileFromDataset,
 } from '../../entities/dataset/dataset.reducer';
 import { Action, ThunkDispatch } from '@reduxjs/toolkit';
-import { Button, ButtonDropdown, Icon, SpaceBetween } from '@cloudscape-design/components';
+import { Button, ButtonDropdown, SpaceBetween } from '@cloudscape-design/components';
 import { useAppDispatch, useAppSelector } from '../../config/store';
 import { copyButtonAriaLabel, deleteButtonAriaLabel, downloadButtonAriaLabel } from './dataset.utils';
 import Condition from '../../modules/condition';
@@ -52,12 +52,6 @@ function DatasetActions (props?: any) {
 
     return (
         <SpaceBetween direction='horizontal' size='xs'>
-            <Button
-                onClick={() => dispatch(getDatasetsList(projectName))}
-                ariaLabel={'Refresh dataset list'}
-            >
-                <Icon name='refresh' />
-            </Button>
             {DatasetActionButton(nav, dispatch, props)}
             {DatasetCreateButton(projectName, createDatasetRef)}
         </SpaceBetween>

--- a/frontend/src/entities/dataset/dataset.reducer.ts
+++ b/frontend/src/entities/dataset/dataset.reducer.ts
@@ -23,6 +23,7 @@ import {
 } from '@reduxjs/toolkit';
 import { IDataset } from '../../shared/model/dataset.model';
 import axios from '../../shared/util/axios-utils';
+import { ServerRequestProps } from '../../shared/util/table-utils';
 
 const initialState = {
     loadingAction: false,
@@ -39,10 +40,10 @@ const initialState = {
 
 export const getDatasetsList = createAsyncThunk(
     'dataset/fetch_entity_list',
-    async (projectName: string | undefined) => {
+    async (params: ServerRequestProps) => {
         let requestUrl = '/dataset';
-        if (projectName !== undefined) {
-            requestUrl = `/project/${projectName}/datasets`;
+        if (params.projectName !== undefined) {
+            requestUrl = `/project/${params.projectName}/datasets`;
         }
         return axios.get<IDataset[]>(requestUrl);
     }
@@ -92,6 +93,9 @@ export const DatasetSlice = createSlice({
     reducers: {
         updateEntity (state, action: PayloadAction<IDataset>) {
             state.dataset = action.payload;
+        },
+        clearDatasetList (state) {
+            state.datasetsList.length = 0;
         },
     },
     extraReducers (builder) {
@@ -153,7 +157,7 @@ export const DatasetSlice = createSlice({
 
 // Reducer
 export default DatasetSlice.reducer;
-export const { updateEntity } = DatasetSlice.actions;
+export const { updateEntity, clearDatasetList } = DatasetSlice.actions;
 export const loadingDatasetsList = (state: any) => state.dataset.loadingDatasetsList;
 export const loadingDataset = (state: any) => state.dataset.loadingDataset;
 export const loadingFiles = (state: any) => state.dataset.loadingFileEntities;

--- a/frontend/src/entities/dataset/dataset.tsx
+++ b/frontend/src/entities/dataset/dataset.tsx
@@ -16,7 +16,7 @@
 
 import React, { RefObject, useEffect, useRef } from 'react';
 import { defaultColumns, visibleColumns, visibleContentPreference } from './dataset.columns';
-import { getDatasetsList, loadingDatasetsList, loadingDatasetAction } from './dataset.reducer';
+import { getDatasetsList, loadingDatasetsList, loadingDatasetAction, clearDatasetList } from './dataset.reducer';
 import { useAppDispatch, useAppSelector } from '../../config/store';
 import Table from '../../modules/table';
 import { IDataset } from '../../shared/model/dataset.model';
@@ -73,6 +73,8 @@ export const Dataset = () => {
                     itemNameProperty='name'
                     loadingItems={loadingDatasets}
                     loadingAction={loadingAction}
+                    serverFetch={getDatasetsList}
+                    storeClear={clearDatasetList}
                 />
             </div>
         )


### PR DESCRIPTION
*Issue #, if available:* N/A. It was just bothering me and I fixed it. 

*Description of changes:*
- Make dataset table use the same refresh button as other tables
- Make dataset table use background refreshing
- Make dataset table use getDatasetsList from reducer
- Make datasets table go to loading state when clicking on refresh button

Before:
![Screenshot 2024-05-07 at 12 39 11 PM](https://github.com/awslabs/mlspace/assets/28429388/7719fba7-2c7e-4b3b-b1e3-211e0e35f2d1)

After:
![Screenshot 2024-05-07 at 12 39 27 PM](https://github.com/awslabs/mlspace/assets/28429388/db95a710-ab14-4423-ad1a-029991d2583f)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
