### PR TITLE
prevent breadcrumbs from reloading all of app layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import { AppLayout, BreadcrumbGroup, BreadcrumbGroupProps } from '@cloudscape-design/components';
+import { AppLayout   } from '@cloudscape-design/components';
 import { HashRouter } from 'react-router-dom';
 import AppRoutes from './routes';
 import ErrorBoundary from './shared/error/error-boundary';
@@ -32,6 +32,7 @@ import SystemBanner from './modules/system-banner';
 import Header from './shared/layout/header/header';
 import NotificationBanner from './shared/layout/notification/notification';
 import { applyTheme } from '@cloudscape-design/components/theming';
+import BreadcrumbsProvider from './shared/layout/navigation/breadcrumbs';
 
 const baseHref = document?.querySelector('base')?.getAttribute('href')?.replace(/\/$/, '');
 
@@ -41,9 +42,7 @@ export default function App () {
     const resourceScheduleModal: ResourceScheduleModalProps = useAppSelector(
         (state) => state.modal.resourceScheduleModal
     );
-    const breadcrumbs: BreadcrumbGroupProps.Item[] = useAppSelector(
-        (state) => state.navigation.breadcrumbs
-    );
+    
     const auth = useAuth();
 
     // Applies custom theming from public/theming.js
@@ -72,7 +71,7 @@ export default function App () {
                     notifications={<NotificationBanner />}
                     stickyNotifications={true}
                     toolsHide={true}
-                    breadcrumbs={<BreadcrumbGroup items={breadcrumbs} ariaLabel='Breadcrumbs' />}
+                    breadcrumbs={<BreadcrumbsProvider/>}
                 />
                 { window.env.SYSTEM_BANNER?.text && <SystemBanner position='BOTTOM' /> }
                 {modal && <DeleteModal {...modal} />}

--- a/frontend/src/shared/layout/navigation/breadcrumbs.tsx
+++ b/frontend/src/shared/layout/navigation/breadcrumbs.tsx
@@ -1,0 +1,32 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { BreadcrumbGroup, BreadcrumbGroupProps } from '@cloudscape-design/components';
+
+import { useAppSelector } from '../../../config/store';
+import React from 'react';
+
+function BreadcrumbsProvider () {
+    const breadcrumbs: BreadcrumbGroupProps.Item[] = useAppSelector(
+        (state) => state.navigation.breadcrumbs
+    );
+
+    return (
+        <BreadcrumbGroup items={breadcrumbs} ariaLabel='Breadcrumbs' />
+    );
+}
+
+export default BreadcrumbsProvider;


### PR DESCRIPTION
*Issue #, if available:* N/A. Improvements from things I have noticed while using the app.

*Description of changes:*
- Move BreadcrumbGroup to its own component so that it does not re-render the whole AppLayout on update. 

Before (slow):
![Recording 2024-05-07 at 17 29 09](https://github.com/awslabs/mlspace/assets/28429388/e8d405ac-a5b3-4c63-87a5-2a4e20fab91d)

After (fast):
![Recording 2024-05-07 at 18 01 50](https://github.com/awslabs/mlspace/assets/28429388/8b91b317-52e9-4a44-a57e-49393a505092)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
