### PR TITLE
Modifying authorizer so anyone can get the app config

### DIFF
--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -68,7 +68,7 @@ def lambda_handler(event, context):
         f"- Method: {request_method}"
     )
 
-    if requested_resource.startswith("/app-config") and request_method == "GET":
+    if requested_resource == "/app-config" and request_method == "GET":
         # Anyone can get the app config
         policy_statement["Effect"] = "Allow"
 
@@ -275,7 +275,7 @@ def lambda_handler(event, context):
                     except Exception as e:
                         logging.exception(e)
                         logging.info("Access Denied. Encountered error while determining resource access policy.")
-            elif requested_resource.startswith("/app-config") and Permission.ADMIN in user.permissions:
+            elif requested_resource == "/app-config" and request_method == "POST" and Permission.ADMIN in user.permissions:
                 # Operations for app-wide configuration can only be performed by admins
                 policy_statement["Effect"] = "Allow"
             elif requested_resource == "/login" and request_method == "PUT":

--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -58,6 +58,20 @@ def lambda_handler(event, context):
         "Resource": event["methodArn"],
     }
 
+    requested_resource = event["resource"]
+    path_params = event["pathParameters"]
+    request_method = event["httpMethod"]
+
+    logger.info(
+        f"Determining access for Resource: {requested_resource} "
+        f"- PathParams: {json.dumps(path_params) if path_params else 'N/A'} "
+        f"- Method: {request_method}"
+    )
+
+    if requested_resource.startswith("/app-config") and request_method == "GET":
+        # Anyone can get the app config
+        policy_statement["Effect"] = "Allow"
+
     client_token = None
     token_failure = False
     auth_header = None
@@ -103,15 +117,6 @@ def lambda_handler(event, context):
         }
 
     username = urllib.parse.unquote(token_info["preferred_username"]).replace(",", "-").replace("=", "-").replace(" ", "-")
-    requested_resource = event["resource"]
-    path_params = event["pathParameters"]
-    request_method = event["httpMethod"]
-
-    logger.info(
-        f"Determining access for Resource: {requested_resource} "
-        f"- PathParams: {json.dumps(path_params) if path_params else 'N/A'} "
-        f"- Method: {request_method}"
-    )
 
     # Only run through the auth logic if the token has not yet expired
     if token_info["exp"] > time.time():
@@ -270,13 +275,9 @@ def lambda_handler(event, context):
                     except Exception as e:
                         logging.exception(e)
                         logging.info("Access Denied. Encountered error while determining resource access policy.")
-            elif requested_resource.startswith("/app-config"):
-                # All users can get the app-wide configuration
-                if request_method == "GET":
-                    policy_statement["Effect"] = "Allow"
-                # Any other operation for app-wide configuration can only be performed by admins
-                elif Permission.ADMIN in user.permissions:
-                    policy_statement["Effect"] = "Allow"
+            elif requested_resource.startswith("/app-config") and Permission.ADMIN in user.permissions:
+                # Operations for app-wide configuration can only be performed by admins
+                policy_statement["Effect"] = "Allow"
             elif requested_resource == "/login" and request_method == "PUT":
                 policy_statement["Effect"] = "Allow"
             elif (

--- a/backend/test/authorizer/test_authorizer.py
+++ b/backend/test/authorizer/test_authorizer.py
@@ -1706,6 +1706,8 @@ def test_config_routes(mock_user_dao, user: UserModel, method: str, allow: bool)
         (MOCK_USER, MOCK_REGULAR_PROJECT_USER, "GET", {"projectName": MOCK_PROJECT_NAME}, True),
         (MOCK_USER, MOCK_REGULAR_PROJECT_USER, "POST", {"projectName": MOCK_PROJECT_NAME}, False),
         (MOCK_OWNER_USER, MOCK_OWNER_PROJECT_USER, "POST", {"projectName": MOCK_PROJECT_NAME}, True),
+        (None, None, "GET", None, True),
+        (None, None, "POST", None, False),
     ],
     ids=[
         "user_update_app_config",
@@ -1714,6 +1716,8 @@ def test_config_routes(mock_user_dao, user: UserModel, method: str, allow: bool)
         "user_get_project_config",
         "user_update_project_config",
         "project_owner_update_project_config",
+        "non_user_get_app_config",
+        "non_user_update_app_config",
     ],
 )
 @mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True)
@@ -1739,7 +1743,8 @@ def test_app_config_routes(
         ),
         {},
     ) == policy_response(allow=allow, user=user)
-    mock_user_dao.get.assert_called_with(user.username)
+    if user:
+        mock_user_dao.get.assert_called_with(user.username)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Description of changes:* Anyone should be able to GET the app config. This change modifies the authorizer so it will allow anyone to make a GET request on the `app-config` resource.

Tested locally on my machine and I no longer get errors on the login screen about the app config not loading.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
