### PR TITLE
[AIML-ADC-8888, AIML-ADC-8887] Notebook creation UI bugs - EMR cluster selection modal and lifecycle config

### DIFF
--- a/backend/src/ml_space_lambda/utils/common_functions.py
+++ b/backend/src/ml_space_lambda/utils/common_functions.py
@@ -283,7 +283,11 @@ def query_resource_metadata(resource_metadata_dao, event, resource_type: Resourc
                 expressions.append(expression_key)
                 filter_values[expression_key] = states[i]
 
-            if resource_type == ResourceType.TRAINING_JOB:
+            if resource_type == ResourceType.EMR_CLUSTER:
+                kwargs["filter_expression"] = f"metadata.#s IN ({', '.join(expressions)})"
+                kwargs["filter_values"] = filter_values
+                kwargs["expression_names"] = {"#s": "Status"}
+            elif resource_type == ResourceType.TRAINING_JOB:
                 kwargs["filter_expression"] = f"metadata.TrainingJobStatus IN ({', '.join(expressions)})"
                 kwargs["filter_values"] = filter_values
 


### PR DESCRIPTION
*Issue #, if available:*
[AIML-ADC-8888] Unable to customize notebook lifecycle config
[AIML-ADC-8887] Terminated EMR clusters displaying in notebook cluster selection modal 

*Description of changes:*
This PR fixes an issue where the EMR cluster selection modal included terminated clusters. It also fixes an issue where it was not possible to select a custom lifecycle config when creating a notebook that was not attached to a cluster. Lastly it fixes an issue with items displayed in the cluster modal related to the migration to the resource metadata APIs for EMR clusters. This fix will be backported to 1.4.x.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
