### PR TITLE
Transition EMR cluster creation to use AppConfig

### DIFF
--- a/backend/src/ml_space_lambda/emr/lambda_functions.py
+++ b/backend/src/ml_space_lambda/emr/lambda_functions.py
@@ -27,17 +27,15 @@ from ml_space_lambda.data_access_objects.project import ProjectDAO
 from ml_space_lambda.data_access_objects.resource_metadata import ResourceMetadataDAO
 from ml_space_lambda.data_access_objects.resource_scheduler import ResourceSchedulerDAO, ResourceSchedulerModel
 from ml_space_lambda.enums import ResourceType
+from ml_space_lambda.utils.app_config_utils import get_app_config
 from ml_space_lambda.utils.common_functions import api_wrapper, generate_tags, query_resource_metadata, retry_config
 from ml_space_lambda.utils.mlspace_config import get_environment_variables, pull_config_from_s3
 
 logger = logging.getLogger(__name__)
 
-s3 = boto3.client("s3", config=retry_config)
 emr = boto3.client("emr", config=retry_config)
 
 resource_metadata_dao = ResourceMetadataDAO()
-
-cluster_config = {}
 
 resource_scheduler_dao = ResourceSchedulerDAO()
 project_dao = ProjectDAO()
@@ -51,26 +49,11 @@ def create(event, context):
     cluster_name = event_body["clusterName"]
     emr_size = event_body["options"]["emrSize"]
     release_version = event_body["options"]["emrRelease"]
+    app_config = get_app_config()
 
     env_variables = get_environment_variables()
 
     custom_ami_id = event_body["options"]["customAmiId"] if "customAmiId" in event_body["options"] else None
-    applications = []
-
-    global cluster_config
-    if not cluster_config:
-        resp = s3.get_object(Bucket=env_variables["BUCKET"], Key=env_variables["CLUSTER_CONFIG_KEY"])
-        cluster_config = json.loads(resp["Body"].read().decode())
-
-    # get list of applications if provided, otherwise use default from
-    # s3 cluster config
-    if event_body.get("options", {}).get("applications", []):
-        application_list = event_body["options"]["applications"]
-        for app in application_list:
-            app_name = {"Name": app}
-            applications.append(app_name)
-    else:
-        applications = cluster_config["applications"]
 
     # use subnet if provided, otherwise choose a random subnet
     # from s3 config file
@@ -79,20 +62,17 @@ def create(event, context):
         param_file = pull_config_from_s3()
         subnet = random.sample(param_file["pSMSSubnetIds"].split(","), 1)[0]
 
-    # Get Custom EC2 Key Pair
-    ec2_key_name = ""
-    if cluster_config["ec2-key"] != "EC2_KEY":
-        ec2_key_name = cluster_config["ec2-key"]
-
-    master_instance_type = cluster_config[emr_size]["master-type"]
-    core_instance_type = cluster_config[emr_size]["core-type"]
-    instance_count = cluster_config[emr_size]["size"]
+    for size in app_config.configuration.emr_config.cluster_sizes:
+        if size.name == emr_size:
+            master_instance_type = size.master_type
+            core_instance_type = size.core_type
+            instance_count = size.size
 
     args = {}
     args["Name"] = cluster_name
     args["LogUri"] = f"s3://{env_variables['LOG_BUCKET']}"
     args["ReleaseLabel"] = release_version
-    args["Applications"] = applications
+    args["Applications"] = app_config.configuration.emr_config.to_dict()["applications"]
     args["Instances"] = {
         "InstanceGroups": [
             {
@@ -110,8 +90,8 @@ def create(event, context):
                 "InstanceCount": instance_count,
                 "AutoScalingPolicy": {
                     "Constraints": {
-                        "MinCapacity": cluster_config["auto-scaling"]["min-instances"],
-                        "MaxCapacity": cluster_config["auto-scaling"]["max-instances"],
+                        "MinCapacity": app_config.configuration.emr_config.auto_scaling.min_instances,
+                        "MaxCapacity": app_config.configuration.emr_config.auto_scaling.max_instances,
                     },
                     "Rules": [
                         {
@@ -119,17 +99,17 @@ def create(event, context):
                             "Description": "Scaling policy configured in the cluster-config.json",
                             "Action": {
                                 "SimpleScalingPolicyConfiguration": {
-                                    "ScalingAdjustment": cluster_config["auto-scaling"]["scale-out"]["increment"],
-                                    "CoolDown": cluster_config["auto-scaling"]["scale-out"]["cooldown"],
+                                    "ScalingAdjustment": app_config.configuration.emr_config.auto_scaling.scale_out.increment,
+                                    "CoolDown": app_config.configuration.emr_config.auto_scaling.scale_out.cooldown,
                                 }
                             },
                             "Trigger": {
                                 "CloudWatchAlarmDefinition": {
                                     "ComparisonOperator": "LESS_THAN",
-                                    "EvaluationPeriods": cluster_config["auto-scaling"]["scale-out"]["eval-periods"],
+                                    "EvaluationPeriods": app_config.configuration.emr_config.auto_scaling.scale_out.eval_periods,
                                     "MetricName": "YARNMemoryAvailablePercentage",
                                     "Period": 300,
-                                    "Threshold": cluster_config["auto-scaling"]["scale-out"]["percentage-mem-available"],
+                                    "Threshold": app_config.configuration.emr_config.auto_scaling.scale_out.percentage_mem_available,
                                     "Unit": "PERCENT",
                                 }
                             },
@@ -139,17 +119,17 @@ def create(event, context):
                             "Description": "Scaling policy configured in the cluster-config.json",
                             "Action": {
                                 "SimpleScalingPolicyConfiguration": {
-                                    "ScalingAdjustment": cluster_config["auto-scaling"]["scale-in"]["increment"],
-                                    "CoolDown": cluster_config["auto-scaling"]["scale-in"]["cooldown"],
+                                    "ScalingAdjustment": app_config.configuration.emr_config.auto_scaling.scale_in.increment,
+                                    "CoolDown": app_config.configuration.emr_config.auto_scaling.scale_in.cooldown,
                                 }
                             },
                             "Trigger": {
                                 "CloudWatchAlarmDefinition": {
                                     "ComparisonOperator": "GREATER_THAN",
-                                    "EvaluationPeriods": cluster_config["auto-scaling"]["scale-in"]["eval-periods"],
+                                    "EvaluationPeriods": app_config.configuration.emr_config.auto_scaling.scale_in.eval_periods,
                                     "MetricName": "YARNMemoryAvailablePercentage",
                                     "Period": 300,
-                                    "Threshold": cluster_config["auto-scaling"]["scale-in"]["percentage-mem-available"],
+                                    "Threshold": app_config.configuration.emr_config.auto_scaling.scale_in.percentage_mem_available,
                                     "Unit": "PERCENT",
                                 }
                             },
@@ -158,7 +138,7 @@ def create(event, context):
                 },
             },
         ],
-        "Ec2KeyName": ec2_key_name,
+        "Ec2KeyName": "EC2_KEY",
         "KeepJobFlowAliveWhenNoSteps": True,
         "TerminationProtected": False,
         "Ec2SubnetId": subnet,

--- a/backend/test/emr/test_create_emr_cluster.py
+++ b/backend/test/emr/test_create_emr_cluster.py
@@ -17,7 +17,6 @@
 import copy
 import json
 import time
-from io import BytesIO
 from typing import Optional
 from unittest import mock
 
@@ -26,7 +25,7 @@ from botocore.exceptions import ClientError
 
 import ml_space_lambda.utils.mlspace_config as mlspace_config
 from ml_space_lambda.data_access_objects.project import ProjectModel
-from ml_space_lambda.enums import ResourceType
+from ml_space_lambda.enums import ResourceType, ServiceType
 from ml_space_lambda.utils.common_functions import generate_html_response, generate_tags
 
 TEST_ENV_CONFIG = {
@@ -42,68 +41,82 @@ TEST_ENV_CONFIG = {
 
 with mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True):
     from ml_space_lambda.emr import lambda_functions as emr_handler
+    from ml_space_lambda.utils.app_config_utils import get_app_config
 
 MOCK_PROJECT_NAME = "example_project"
 MOCK_CLUSTER_NAME = "example_cluster_name"
+MOCK_RELEASE_LABEL = "emr-6.2.0"
 
-mock_cluster_config = {
-    "applications": [{"Name": "Hadoop"}, {"Name": "Hue"}],
-    "log-location": "s3://example_bucket",
-    "release": "emr-6.2.0",
-    "ami": "ami-0acee44940796046c",
-    "example_emr_size": {
-        "master-type": "ml.g5.48xlarge",
-        "core-type": "ml.g5.24xlarge",
-        "size": 3,
-    },
-    "auto-scaling": {
-        "min-instances": 1,
-        "max-instances": 3,
-        "scale-out": {
-            "cooldown": 0,
-            "increment": 5,
-            "eval-periods": 1,
-            "percentage-mem-available": 20,
+MOCK_APP_CONFIG = {
+    "configScope": "global",
+    "versionId": 1,
+    "changeReason": "Testing",
+    "changedBy": "Tester",
+    "createdAt": 1,
+    "configuration": {
+        "DisabledInstanceTypes": {
+            ServiceType.NOTEBOOK.value: [],
+            ServiceType.ENDPOINT.value: [],
+            ServiceType.TRAINING_JOB.value: [],
+            ServiceType.TRANSFORM_JOB.value: [],
         },
-        "scale-in": {
-            "cooldown": 0,
-            "increment": -5,
-            "eval-periods": 1,
-            "percentage-mem-available": 20,
+        "EnabledServices": {
+            ServiceType.REALTIME_TRANSLATE.value: "true",
+            ServiceType.BATCH_TRANSLATE.value: "false",
+            ServiceType.LABELING_JOB.value: "true",
+            ServiceType.EMR_CLUSTER.value: "true",
+            ServiceType.ENDPOINT.value: "true",
+            ServiceType.ENDPOINT_CONFIG.value: "false",
+            ServiceType.HPO_JOB.value: "true",
+            ServiceType.MODEL.value: "true",
+            ServiceType.NOTEBOOK.value: "false",
+            ServiceType.TRAINING_JOB.value: "true",
+            ServiceType.TRANSFORM_JOB.value: "true",
+        },
+        "EMRConfig": {
+            "clusterSizes": [
+                {"name": "Small", "size": 3, "masterType": "m5.xlarge", "coreType": "m5.xlarge"},
+            ],
+            "autoScaling": {
+                "minInstances": 2,
+                "maxInstances": 15,
+                "scaleOut": {"increment": 1, "percentageMemAvailable": 15, "evalPeriods": 1, "cooldown": 300},
+                "scaleIn": {"increment": -1, "percentageMemAvailable": 75, "evalPeriods": 1, "cooldown": 300},
+            },
+            "applications": [
+                {"name": "Hadoop"},
+                {"name": "Spark"},
+            ],
         },
     },
-    "ec2-key": "example_ec2_key",
 }
-
-
-mock_cluster_config_response = {"Body": BytesIO(bytes(json.dumps(mock_cluster_config), "utf-8"))}
 
 
 def _expected_args(custom_ami: Optional[str] = None):
     expected_args = {
         "Name": "example_cluster_name",
         "LogUri": "s3://mlspace-log-bucket",
-        "ReleaseLabel": mock_cluster_config["release"],
-        "Applications": [{"Name": "Hive"}, {"Name": "HBase"}],
+        "ReleaseLabel": MOCK_RELEASE_LABEL,
+        "Applications": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["applications"],
         "Instances": {
             "InstanceGroups": [
                 {
                     "Name": "Master",
                     "Market": "ON_DEMAND",
                     "InstanceRole": "MASTER",
-                    "InstanceType": "ml.g5.48xlarge",
+                    "InstanceType": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["clusterSizes"][0]["masterType"],
                     "InstanceCount": 1,
                 },
                 {
                     "Name": "Worker",
                     "Market": "ON_DEMAND",
                     "InstanceRole": "CORE",
-                    "InstanceType": "ml.g5.24xlarge",
+                    "InstanceType": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["clusterSizes"][0]["coreType"],
                     "InstanceCount": 3,
                     "AutoScalingPolicy": {
                         "Constraints": {
-                            "MinCapacity": mock_cluster_config["auto-scaling"]["min-instances"],
-                            "MaxCapacity": mock_cluster_config["auto-scaling"]["max-instances"],
+                            "MinCapacity": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"]["minInstances"],
+                            "MaxCapacity": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"]["maxInstances"],
                         },
                         "Rules": [
                             {
@@ -111,18 +124,24 @@ def _expected_args(custom_ami: Optional[str] = None):
                                 "Description": "Scaling policy configured in the cluster-config.json",
                                 "Action": {
                                     "SimpleScalingPolicyConfiguration": {
-                                        "ScalingAdjustment": mock_cluster_config["auto-scaling"]["scale-out"]["increment"],
-                                        "CoolDown": mock_cluster_config["auto-scaling"]["scale-out"]["cooldown"],
+                                        "ScalingAdjustment": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"][
+                                            "scaleOut"
+                                        ]["increment"],
+                                        "CoolDown": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"]["scaleOut"][
+                                            "cooldown"
+                                        ],
                                     }
                                 },
                                 "Trigger": {
                                     "CloudWatchAlarmDefinition": {
                                         "ComparisonOperator": "LESS_THAN",
-                                        "EvaluationPeriods": mock_cluster_config["auto-scaling"]["scale-out"]["eval-periods"],
+                                        "EvaluationPeriods": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"][
+                                            "scaleOut"
+                                        ]["evalPeriods"],
                                         "MetricName": "YARNMemoryAvailablePercentage",
                                         "Period": 300,
-                                        "Threshold": mock_cluster_config["auto-scaling"]["scale-out"][
-                                            "percentage-mem-available"
+                                        "Threshold": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"]["scaleOut"][
+                                            "percentageMemAvailable"
                                         ],
                                         "Unit": "PERCENT",
                                     }
@@ -133,18 +152,24 @@ def _expected_args(custom_ami: Optional[str] = None):
                                 "Description": "Scaling policy configured in the cluster-config.json",
                                 "Action": {
                                     "SimpleScalingPolicyConfiguration": {
-                                        "ScalingAdjustment": mock_cluster_config["auto-scaling"]["scale-in"]["increment"],
-                                        "CoolDown": mock_cluster_config["auto-scaling"]["scale-in"]["cooldown"],
+                                        "ScalingAdjustment": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"][
+                                            "scaleIn"
+                                        ]["increment"],
+                                        "CoolDown": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"]["scaleIn"][
+                                            "cooldown"
+                                        ],
                                     }
                                 },
                                 "Trigger": {
                                     "CloudWatchAlarmDefinition": {
                                         "ComparisonOperator": "GREATER_THAN",
-                                        "EvaluationPeriods": mock_cluster_config["auto-scaling"]["scale-in"]["eval-periods"],
+                                        "EvaluationPeriods": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"][
+                                            "scaleIn"
+                                        ]["evalPeriods"],
                                         "MetricName": "YARNMemoryAvailablePercentage",
                                         "Period": 300,
-                                        "Threshold": mock_cluster_config["auto-scaling"]["scale-in"][
-                                            "percentage-mem-available"
+                                        "Threshold": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["autoScaling"]["scaleIn"][
+                                            "percentageMemAvailable"
                                         ],
                                         "Unit": "PERCENT",
                                     }
@@ -154,7 +179,7 @@ def _expected_args(custom_ami: Optional[str] = None):
                     },
                 },
             ],
-            "Ec2KeyName": mock_cluster_config["ec2-key"],
+            "Ec2KeyName": "EC2_KEY",
             "KeepJobFlowAliveWhenNoSteps": True,
             "TerminationProtected": False,
             "Ec2SubnetId": "subnet1",
@@ -180,8 +205,7 @@ def _expected_args(custom_ami: Optional[str] = None):
 
 def _mock_event_body(subnet: Optional[str] = "", custom_ami: Optional[str] = None):
     options = {
-        "emrSize": "example_emr_size",
-        "applications": ["Hive", "HBase"],
+        "emrSize": MOCK_APP_CONFIG["configuration"]["EMRConfig"]["clusterSizes"][0]["name"],
         "emrRelease": "emr-6.2.0",
     }
     if custom_ami:
@@ -259,9 +283,9 @@ def _mock_event(subnet: Optional[str] = "", custom_ami: Optional[str] = None):
     ],
 )
 @mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True)
+@mock.patch("ml_space_lambda.utils.app_config_utils.app_configuration_dao")
 @mock.patch("ml_space_lambda.emr.lambda_functions.resource_scheduler_dao")
 @mock.patch("ml_space_lambda.emr.lambda_functions.project_dao")
-@mock.patch("ml_space_lambda.emr.lambda_functions.s3")
 @mock.patch("ml_space_lambda.emr.lambda_functions.random")
 @mock.patch("ml_space_lambda.emr.lambda_functions.pull_config_from_s3")
 @mock.patch("ml_space_lambda.emr.lambda_functions.emr")
@@ -269,9 +293,9 @@ def test_create_emr_cluster_success(
     mock_emr,
     mock_pull_config,
     mock_random,
-    mock_s3,
     mock_project_dao,
     mock_resource_scheduler_dao,
+    mock_app_configuration_dao,
     mock_ami_id,
 ):
     # clear out global config if set to make lambda tests independent of each other
@@ -282,7 +306,8 @@ def test_create_emr_cluster_success(
     mocked_random_subnet = "example_subnet2"
     mock_random.sample.return_value = [mocked_random_subnet]
 
-    mock_s3.get_object.return_value = copy.deepcopy(mock_cluster_config_response)
+    mock_app_configuration_dao.get.return_value = [MOCK_APP_CONFIG]
+    get_app_config.cache_clear()
     mock_emr.run_job_flow.return_value = mock_response
     mock_paginator = mock.MagicMock()
     mock_emr.get_paginator.return_value = mock_paginator
@@ -296,7 +321,6 @@ def test_create_emr_cluster_success(
 
     mock_emr.run_job_flow.assert_called_with(**_mock_args(specific_subnet=mocked_random_subnet, custom_ami=mock_ami_id))
     mock_pull_config.assert_called_once()
-    mock_s3.get_object.assert_called_with(Bucket="example_bucket", Key="cluster-config.json")
 
     cluster_schedule = mock_resource_scheduler_dao.create.call_args.args[0]
     assert cluster_schedule.resource_id == mock_cluster_id
@@ -307,17 +331,13 @@ def test_create_emr_cluster_success(
 
 
 @mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True)
+@mock.patch("ml_space_lambda.utils.app_config_utils.app_configuration_dao")
 @mock.patch("ml_space_lambda.emr.lambda_functions.resource_scheduler_dao")
 @mock.patch("ml_space_lambda.emr.lambda_functions.project_dao")
-@mock.patch("ml_space_lambda.emr.lambda_functions.s3")
 @mock.patch("ml_space_lambda.emr.lambda_functions.pull_config_from_s3")
 @mock.patch("ml_space_lambda.emr.lambda_functions.emr")
 def test_create_emr_cluster_success_with_subnet(
-    mock_emr,
-    mock_pull_config,
-    mock_s3,
-    mock_project_dao,
-    mock_resource_scheduler_dao,
+    mock_emr, mock_pull_config, mock_project_dao, mock_resource_scheduler_dao, mock_app_configuration_dao
 ):
     # This test checks to see that the response contains the expected subnet that the user specifies.
 
@@ -329,7 +349,8 @@ def test_create_emr_cluster_success_with_subnet(
     specific_subnet = "ThisIsASpecificSubnet1"
     mock_ami_id = "ami-123456789"
 
-    mock_s3.get_object.return_value = copy.deepcopy(mock_cluster_config_response)
+    mock_app_configuration_dao.get.return_value = [MOCK_APP_CONFIG]
+    get_app_config.cache_clear()
     mock_emr.run_job_flow.return_value = mock_response
     mock_paginator = mock.MagicMock()
     mock_emr.get_paginator.return_value = mock_paginator
@@ -344,7 +365,6 @@ def test_create_emr_cluster_success_with_subnet(
     # Check it had correct parameters and subnet was passed in
     mock_emr.run_job_flow.assert_called_with(**_mock_args(specific_subnet=specific_subnet, custom_ami=mock_ami_id))
     mock_pull_config.assert_not_called()
-    mock_s3.get_object.assert_called_with(Bucket="example_bucket", Key="cluster-config.json")
 
     # Check it was created successfully
     cluster_schedule = mock_resource_scheduler_dao.create.call_args.args[0]
@@ -356,10 +376,10 @@ def test_create_emr_cluster_success_with_subnet(
 
 
 @mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True)
-@mock.patch("ml_space_lambda.emr.lambda_functions.s3")
+@mock.patch("ml_space_lambda.utils.app_config_utils.app_configuration_dao")
 @mock.patch("ml_space_lambda.emr.lambda_functions.pull_config_from_s3")
 @mock.patch("ml_space_lambda.emr.lambda_functions.emr")
-def test_create_emr_cluster_client_error(mock_emr, mock_pull_config, mock_s3):
+def test_create_emr_cluster_client_error(mock_emr, mock_pull_config, mock_app_configuration_dao):
     # clear out global config if set to make lambda tests independent of each other
     mlspace_config.param_file = {}
     mlspace_config.env_variables = {}
@@ -376,13 +396,13 @@ def test_create_emr_cluster_client_error(mock_emr, mock_pull_config, mock_s3):
 
     specific_subnet = "ADifferentSubnet"
 
-    mock_s3.get_object.return_value = copy.deepcopy(mock_cluster_config_response)
+    mock_app_configuration_dao.get.return_value = [MOCK_APP_CONFIG]
+    get_app_config.cache_clear()
     mock_emr.run_job_flow.side_effect = ClientError(error_msg, "RunJobFlow")
 
     assert emr_handler.create(_mock_event(subnet=specific_subnet), mock_context) == expected_response
 
     mock_pull_config.assert_not_called()
-    mock_s3.get_object.assert_called_with(Bucket="example_bucket", Key="cluster-config.json")
     error_args = _mock_args(specific_subnet=specific_subnet)
     mock_emr.run_job_flow.assert_called_with(**error_args)
 


### PR DESCRIPTION
*Description of changes:* Right now EMR uses values from the cluster-config.json file for determining cluster configuration at creation. This PR will transition EMR creation to using app config wherever possible.

TODO: In a followup commit I'm going to remove cluster-config.json altogether since it shouldn't be necessary at all anymore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
