### PR TITLE
fixes issues where datasets were listing incorrectly

### DIFF
--- a/frontend/src/entities/dataset/dataset.reducer.ts
+++ b/frontend/src/entities/dataset/dataset.reducer.ts
@@ -40,9 +40,9 @@ const initialState = {
 
 export const getDatasetsList = createAsyncThunk(
     'dataset/fetch_entity_list',
-    async (params: ServerRequestProps) => {
+    async (params?: ServerRequestProps) => {
         let requestUrl = '/dataset';
-        if (params.projectName !== undefined) {
+        if (params?.projectName !== undefined) {
             requestUrl = `/project/${params.projectName}/datasets`;
         }
         return axios.get<IDataset[]>(requestUrl);

--- a/frontend/src/entities/dataset/dataset.reducer.ts
+++ b/frontend/src/entities/dataset/dataset.reducer.ts
@@ -40,7 +40,7 @@ const initialState = {
 
 export const getDatasetsList = createAsyncThunk(
     'dataset/fetch_entity_list',
-    async (params?: ServerRequestProps) => {
+    async (params: ServerRequestProps) => {
         let requestUrl = '/dataset';
         if (params?.projectName !== undefined) {
             requestUrl = `/project/${params.projectName}/datasets`;

--- a/frontend/src/entities/dataset/dataset.tsx
+++ b/frontend/src/entities/dataset/dataset.tsx
@@ -39,7 +39,6 @@ export const Dataset = () => {
     !projectName ? DocTitle('Datasets') : DocTitle(projectName!.concat(' Datasets'));
 
     useEffect(() => {
-        dispatch(getDatasetsList({projectName}));
         dispatch(
             setBreadcrumbs([
                 getBase(projectName),

--- a/frontend/src/entities/dataset/dataset.tsx
+++ b/frontend/src/entities/dataset/dataset.tsx
@@ -39,7 +39,7 @@ export const Dataset = () => {
     !projectName ? DocTitle('Datasets') : DocTitle(projectName!.concat(' Datasets'));
 
     useEffect(() => {
-        dispatch(getDatasetsList(projectName));
+        dispatch(getDatasetsList({projectName}));
         dispatch(
             setBreadcrumbs([
                 getBase(projectName),

--- a/frontend/src/modules/dataset/dataset-browser.tsx
+++ b/frontend/src/modules/dataset/dataset-browser.tsx
@@ -110,7 +110,7 @@ export function DatasetBrowser (props: DatasetBrowserProps) {
     }, [dispatch, isCreating, notificationService, projectName, username]);
 
     const fetchDatasets = useCallback((type: DatasetType) => {
-        dispatch(getDatasetsList(projectName)).then((response) => {
+        dispatch(getDatasetsList({projectName})).then((response) => {
             if (isFulfilled(response)) {
                 setState({
                     type: DatasetActionType.State,

--- a/frontend/src/modules/table/table.types.tsx
+++ b/frontend/src/modules/table/table.types.tsx
@@ -56,7 +56,7 @@ type TableProps<Entry = TableEntry> = {
     focusProps?: any;
     focusFileUploadProps?: any;
     serverRequestProps?: ServerRequestProps;
-    serverFetch?: AsyncThunk<any, ServerRequestProps, any>;
+    serverFetch?: AsyncThunk<any, ServerRequestProps | undefined, any>;
     storeClear?: ActionCreatorWithoutPayload;
 };
 

--- a/frontend/src/modules/table/table.types.tsx
+++ b/frontend/src/modules/table/table.types.tsx
@@ -56,7 +56,7 @@ type TableProps<Entry = TableEntry> = {
     focusProps?: any;
     focusFileUploadProps?: any;
     serverRequestProps?: ServerRequestProps;
-    serverFetch?: AsyncThunk<any, ServerRequestProps | undefined, any>;
+    serverFetch?: AsyncThunk<any, ServerRequestProps, any>;
     storeClear?: ActionCreatorWithoutPayload;
 };
 

--- a/frontend/src/shared/util/hooks.ts
+++ b/frontend/src/shared/util/hooks.ts
@@ -53,9 +53,7 @@ export function useBackgroundRefresh (action: () => void, deps: readonly unknown
                 clearInterval(timerId);
             };
         }
-        // We only want to recreate the interval if the condition changes
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [condition]);
+    }, [callbackAction, condition]);
     return isBackgroundRefreshing;
 }
 

--- a/frontend/src/shared/util/hooks.ts
+++ b/frontend/src/shared/util/hooks.ts
@@ -47,7 +47,6 @@ export function useBackgroundRefresh (action: () => void, deps: readonly unknown
                     setIsBackgroundRefreshing(false);
                 }, waitTime);
             }, (window.env.BACKGROUND_REFRESH_INTERVAL || 60) * 1000);
-
             
             return () => {
                 clearInterval(timerId);

--- a/frontend/src/shared/util/table-utils.tsx
+++ b/frontend/src/shared/util/table-utils.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     Link,
     StatusIndicator,
@@ -224,7 +224,7 @@ export type ServerSidePaginatorProps<T extends ServerRequestProps> = {
     loading: PaginationLoadingState;
     requestProps?: T;
     setLoading: React.Dispatch<React.SetStateAction<PaginationLoadingState>>;
-    fetchDataThunk: AsyncThunk<any, T | undefined, any>;
+    fetchDataThunk: AsyncThunk<any, T, any>;
     ariaLabels: PaginationProps.Labels;
     storeClear: ActionCreatorWithoutPayload;
 };
@@ -238,7 +238,7 @@ export const ServerSidePaginator = <T extends ServerRequestProps>(props: ServerS
     const loading = props.loading;
     const setLoading = props.setLoading;
 
-    const fetchData = useCallback(async (usePagination: boolean, callback?: () => void) => {
+    const fetchData = async (usePagination: boolean, callback?: () => void) => {
         // Disable pagination user input until loading completes
         setDisabled(true);
 
@@ -256,7 +256,7 @@ export const ServerSidePaginator = <T extends ServerRequestProps>(props: ServerS
         }
         callback?.();
         setDisabled(false);
-    }, [dispatch, loading, nextToken, projectName, props, setLoading]);
+    };
 
     useEffect(() => {
         if (loading.loadingEmpty) {

--- a/frontend/src/shared/util/table-utils.tsx
+++ b/frontend/src/shared/util/table-utils.tsx
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
     Link,
     StatusIndicator,
@@ -224,7 +224,7 @@ export type ServerSidePaginatorProps<T extends ServerRequestProps> = {
     loading: PaginationLoadingState;
     requestProps?: T;
     setLoading: React.Dispatch<React.SetStateAction<PaginationLoadingState>>;
-    fetchDataThunk: AsyncThunk<any, T, any>;
+    fetchDataThunk: AsyncThunk<any, T | undefined, any>;
     ariaLabels: PaginationProps.Labels;
     storeClear: ActionCreatorWithoutPayload;
 };
@@ -238,7 +238,7 @@ export const ServerSidePaginator = <T extends ServerRequestProps>(props: ServerS
     const loading = props.loading;
     const setLoading = props.setLoading;
 
-    const fetchData = async (usePagination: boolean, callback?: () => void) => {
+    const fetchData = useCallback(async (usePagination: boolean, callback?: () => void) => {
         // Disable pagination user input until loading completes
         setDisabled(true);
 
@@ -256,7 +256,7 @@ export const ServerSidePaginator = <T extends ServerRequestProps>(props: ServerS
         }
         callback?.();
         setDisabled(false);
-    };
+    }, [dispatch, loading, nextToken, projectName, props, setLoading]);
 
     useEffect(() => {
         if (loading.loadingEmpty) {
@@ -271,7 +271,7 @@ export const ServerSidePaginator = <T extends ServerRequestProps>(props: ServerS
     const isBackgroundRefreshing = useBackgroundRefresh(async () => {
         await fetchData(false);
         setLoading({ loadingAdditional: false, loadingEmpty: false, loadingInBackground: true });
-    });
+    }, [fetchData, setLoading]);
     
     useEffect(() => {
         setLoading({ ...loading, loadingInBackground: isBackgroundRefreshing });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This fixes two separate issues.

- Table (specifically for background refresh) wasn't declaring dependencies properly so changes to `projectName` from `useParams()` wasn't triggering re-computing memoized functions.
- Recent changes to `getDatasetsList` thunk was causing the wrong API endpoint to be hit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
