### PR TITLE
Updating FE code to respect Dynamo config for enabled services

### DIFF
--- a/frontend/src/entities/configuration/configuration-reducer.ts
+++ b/frontend/src/entities/configuration/configuration-reducer.ts
@@ -22,6 +22,7 @@ import {
     PayloadAction,
 } from '@reduxjs/toolkit';
 import axios from '../../shared/util/axios-utils';
+import {setEnabledServices} from '../../shared/layout/navigation/navigation.reducer';
 import { defaultConfiguration, IAppConfiguration } from '../../shared/model/app.configuration.model';
 
 const initialState = {
@@ -37,7 +38,7 @@ export const getConfiguration = (configScope: string) => {
 
 export const listConfigurations = createAsyncThunk(
     'app_config/list_configurations',
-    async (props: ListAppConfigurationProps) => {
+    async (props: ListAppConfigurationProps, { dispatch }) => {
         const searchParams = new URLSearchParams();
         searchParams.set('configScope', props.configScope);
         if (props.numVersions) {
@@ -45,7 +46,10 @@ export const listConfigurations = createAsyncThunk(
         }
         const requestUrl = `/app-config?${searchParams}`;
         
-        return await axios.get<IAppConfiguration[]>(requestUrl);
+        const response =  await axios.get<IAppConfiguration[]>(requestUrl);
+        dispatch(setEnabledServices(response.data[0].configuration.EnabledServices));
+
+        return response;
     }
 );
 

--- a/frontend/src/entities/project/detail/project-detail.tsx
+++ b/frontend/src/entities/project/detail/project-detail.tsx
@@ -62,10 +62,10 @@ function ProjectDetail () {
             .catch(() => {
                 navigate('/404');
             });
-        dispatch(setItemsForProjectName({ 'project': projectName, 'enabledServices': applicationConfig.configuration.EnabledServices }));
+        dispatch(setItemsForProjectName(projectName));
         dispatch(setBreadcrumbs([getBase(projectName)]));
         dispatch(setActiveHref('/#'));
-    }, [dispatch, navigate, projectName, project.name, applicationConfig.configuration.EnabledServices]);
+    }, [dispatch, navigate, projectName, project.name]);
 
     // Refresh data in the background to keep state fresh
     const isBackgroundRefreshing = useBackgroundRefresh(async () => {

--- a/frontend/src/entities/project/detail/project-detail.tsx
+++ b/frontend/src/entities/project/detail/project-detail.tsx
@@ -62,10 +62,10 @@ function ProjectDetail () {
             .catch(() => {
                 navigate('/404');
             });
-        dispatch(setItemsForProjectName(projectName));
+        dispatch(setItemsForProjectName({ 'project': projectName, 'enabledServices': applicationConfig.configuration.EnabledServices }));
         dispatch(setBreadcrumbs([getBase(projectName)]));
         dispatch(setActiveHref('/#'));
-    }, [dispatch, navigate, projectName, project.name]);
+    }, [dispatch, navigate, projectName, project.name, applicationConfig.configuration.EnabledServices]);
 
     // Refresh data in the background to keep state fresh
     const isBackgroundRefreshing = useBackgroundRefresh(async () => {
@@ -209,12 +209,12 @@ function ProjectDetail () {
                                     <ProjectResourceCount iconName='status-stopped' variantStyle='subtle' resourceKey={`${ResourceType.NOTEBOOK}.Stopped`} resourceLabel='Stopped' />
                                 </ProjectResourceRow>
 
-                                <ProjectResourceRow label='EMR clusters' path='emr'>
+                                {applicationConfig.configuration.EnabledServices.emrCluster && <ProjectResourceRow label='EMR clusters' path='emr'>
                                     <ProjectResourceCount iconName='add-plus' variantStyle='subtle' resourceKey={`${ResourceType.EMR_CLUSTER}.Total`} resourceLabel='Total' />
                                     <ProjectResourceCount iconName='status-in-progress' variantStyle='success' resourceKey={`${ResourceType.EMR_CLUSTER}.RUNNING`} resourceLabel='Running' />
                                     <ProjectResourceCount iconName='status-pending' variantStyle='subtle' resourceKey={`${ResourceType.EMR_CLUSTER}.STARTING`} resourceLabel='Starting' />
                                     <ProjectResourceCount iconName='status-positive' variantStyle='success' resourceKey={`${ResourceType.EMR_CLUSTER}.WAITING`} resourceLabel='Waiting' />
-                                </ProjectResourceRow>
+                                </ProjectResourceRow>}
 
                                 <ProjectResourceRow label='Endpoints' path='endpoint'>
                                     <ProjectResourceCount iconName='add-plus' variantStyle='subtle' resourceKey={`${ResourceType.ENDPOINT}.Total`} resourceLabel='Total' />

--- a/frontend/src/entities/routes.tsx
+++ b/frontend/src/entities/routes.tsx
@@ -140,26 +140,34 @@ const EntityRoutes = () => {
                     element={<TransformJobRoutes />}
                 />
 
-                <Route path='project/:projectName/emr' element={<EMRClusters />} />
-                <Route path='project/:projectName/emr/create' element={<EMRClusterCreate />} />
-                <Route
-                    path='project/:projectName/emr/:clusterId/:clusterName'
-                    element={<EMRDetail />}
-                />
-                {applicationConfig.configuration.EnabledServices.batchTranslate ? (
-                    <Route
-                        path='project/:projectName/batch-translate'
-                        element={<BatchTranslate />}
-                    />
+                {applicationConfig.configuration.EnabledServices.emrCluster ? (
+                    <>
+                        <Route path='project/:projectName/emr' element={<EMRClusters />} />
+
+                        <Route path='project/:projectName/emr/create' element={<EMRClusterCreate />} />
+                        <Route
+                            path='project/:projectName/emr/:clusterId/:clusterName'
+                            element={<EMRDetail />}
+                        />
+                    </>
                 ) : undefined}
-                <Route
-                    path='project/:projectName/batch-translate/create'
-                    element={<BatchTranslateCreate />}
-                />
-                <Route
-                    path='project/:projectName/batch-translate/:jobId'
-                    element={<BatchTranslateDetail />}
-                />
+                {applicationConfig.configuration.EnabledServices.batchTranslate ? (
+                    <>
+                        <Route
+                            path='project/:projectName/batch-translate'
+                            element={<BatchTranslate />}
+                        />
+
+                        <Route
+                            path='project/:projectName/batch-translate/create'
+                            element={<BatchTranslateCreate />}
+                        />
+                        <Route
+                            path='project/:projectName/batch-translate/:jobId'
+                            element={<BatchTranslateDetail />}
+                        />
+                    </>
+                ) : undefined}
                 <Route path='*' element={<ResourceNotFound />} />
             </ErrorBoundaryRoutes>
         </div>

--- a/frontend/src/modules/resource-not-found/resource-not-found.tsx
+++ b/frontend/src/modules/resource-not-found/resource-not-found.tsx
@@ -22,19 +22,22 @@ import {
     setBreadcrumbs,
     setItemsForProjectName,
 } from '../../shared/layout/navigation/navigation.reducer';
-import { useAppDispatch } from '../../config/store';
+import {useAppDispatch, useAppSelector} from '../../config/store';
 import { getBase } from '../../shared/util/breadcrumb-utils';
 import Logo from '../../shared/layout/logo/logo';
+import {IAppConfiguration} from '../../shared/model/app.configuration.model';
+import {appConfig} from '../../entities/configuration/configuration-reducer';
 
 export default function ResourceNotFound () {
     const dispatch = useAppDispatch();
+    const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     DocTitle('Not Found');
 
     useEffect(() => {
-        dispatch(setItemsForProjectName());
+        dispatch(setItemsForProjectName({ 'enabledServices': applicationConfig.configuration.EnabledServices }));
         dispatch(setBreadcrumbs([getBase(undefined)]));
         dispatch(setActiveHref('/#'));
-    }, [dispatch]);
+    }, [dispatch, applicationConfig.configuration.EnabledServices]);
     return (
         <Container>
             <Grid gridDefinition={[{ colspan: 3, offset: { xxs: 2 } }, { colspan: 4 }]}>

--- a/frontend/src/modules/resource-not-found/resource-not-found.tsx
+++ b/frontend/src/modules/resource-not-found/resource-not-found.tsx
@@ -22,22 +22,19 @@ import {
     setBreadcrumbs,
     setItemsForProjectName,
 } from '../../shared/layout/navigation/navigation.reducer';
-import {useAppDispatch, useAppSelector} from '../../config/store';
+import {useAppDispatch} from '../../config/store';
 import { getBase } from '../../shared/util/breadcrumb-utils';
 import Logo from '../../shared/layout/logo/logo';
-import {IAppConfiguration} from '../../shared/model/app.configuration.model';
-import {appConfig} from '../../entities/configuration/configuration-reducer';
 
 export default function ResourceNotFound () {
     const dispatch = useAppDispatch();
-    const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     DocTitle('Not Found');
 
     useEffect(() => {
-        dispatch(setItemsForProjectName({ 'enabledServices': applicationConfig.configuration.EnabledServices }));
+        dispatch(setItemsForProjectName());
         dispatch(setBreadcrumbs([getBase(undefined)]));
         dispatch(setActiveHref('/#'));
-    }, [dispatch, applicationConfig.configuration.EnabledServices]);
+    }, [dispatch]);
     return (
         <Container>
             <Grid gridDefinition={[{ colspan: 3, offset: { xxs: 2 } }, { colspan: 4 }]}>

--- a/frontend/src/shared/layout/home/home.tsx
+++ b/frontend/src/shared/layout/home/home.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { useEffect } from 'react';
-import { useAppDispatch } from '../../../config/store';
+import {useAppDispatch, useAppSelector} from '../../../config/store';
 import {
     setActiveHref,
     setBreadcrumbs,
@@ -25,17 +25,19 @@ import ProjectCards from '../../../entities/project/card';
 import { selectProject } from '../../../entities/project/card/project-card.reducer';
 import { ContentLayout, Header } from '@cloudscape-design/components';
 import { resetCurrentProject } from '../../../entities/project/project.reducer';
+import {appConfig} from '../../../entities/configuration/configuration-reducer';
+import {IAppConfiguration} from '../../model/app.configuration.model';
 
 export const Home = () => {
     const dispatch = useAppDispatch();
-
+    const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     useEffect(() => {
         dispatch(selectProject());
         dispatch(setBreadcrumbs([]));
         dispatch(setActiveHref('/#'));
-        dispatch(setItemsForProjectName());
+        dispatch(setItemsForProjectName({'enabledServices': applicationConfig.configuration.EnabledServices}));
         dispatch(resetCurrentProject());
-    }, [dispatch]);
+    }, [dispatch, applicationConfig.configuration.EnabledServices]);
 
     return (
         <ContentLayout

--- a/frontend/src/shared/layout/home/home.tsx
+++ b/frontend/src/shared/layout/home/home.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { useEffect } from 'react';
-import {useAppDispatch, useAppSelector} from '../../../config/store';
+import {useAppDispatch} from '../../../config/store';
 import {
     setActiveHref,
     setBreadcrumbs,
@@ -25,19 +25,16 @@ import ProjectCards from '../../../entities/project/card';
 import { selectProject } from '../../../entities/project/card/project-card.reducer';
 import { ContentLayout, Header } from '@cloudscape-design/components';
 import { resetCurrentProject } from '../../../entities/project/project.reducer';
-import {appConfig} from '../../../entities/configuration/configuration-reducer';
-import {IAppConfiguration} from '../../model/app.configuration.model';
 
 export const Home = () => {
     const dispatch = useAppDispatch();
-    const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     useEffect(() => {
         dispatch(selectProject());
         dispatch(setBreadcrumbs([]));
         dispatch(setActiveHref('/#'));
-        dispatch(setItemsForProjectName({'enabledServices': applicationConfig.configuration.EnabledServices}));
+        dispatch(setItemsForProjectName());
         dispatch(resetCurrentProject());
-    }, [dispatch, applicationConfig.configuration.EnabledServices]);
+    }, [dispatch]);
 
     return (
         <ContentLayout

--- a/frontend/src/shared/layout/navigation/navigation.reducer.ts
+++ b/frontend/src/shared/layout/navigation/navigation.reducer.ts
@@ -16,6 +16,13 @@
 
 import { BreadcrumbGroupProps, SideNavigationProps } from '@cloudscape-design/components';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {IEnabledServices} from '../../model/app.configuration.model';
+
+export type NavigationReducerState = {
+    project?: string;
+    enabledServices: IEnabledServices;
+};
+
 
 const initialState = {
     breadcrumbs: [] as BreadcrumbGroupProps.Item[],
@@ -51,7 +58,7 @@ const navigationSlice = createSlice({
                 state.adminItems = undefined;
             }
         },
-        setItemsForProjectName (state, action: PayloadAction<any | undefined>) {
+        setItemsForProjectName (state, action: PayloadAction<NavigationReducerState | undefined>) {
             const projectName = action.payload?.project;
             if (projectName) {
                 const translateItems: any = action.payload?.enabledServices?.batchTranslate

--- a/frontend/src/shared/layout/navigation/navigation.reducer.ts
+++ b/frontend/src/shared/layout/navigation/navigation.reducer.ts
@@ -18,17 +18,12 @@ import { BreadcrumbGroupProps, SideNavigationProps } from '@cloudscape-design/co
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import {IEnabledServices} from '../../model/app.configuration.model';
 
-export type NavigationReducerState = {
-    project?: string;
-    enabledServices: IEnabledServices;
-};
-
-
 const initialState = {
     breadcrumbs: [] as BreadcrumbGroupProps.Item[],
     activeHref: '#/',
     navItems: [] as SideNavigationProps.Item[],
     adminItems: undefined as SideNavigationProps.Item | undefined,
+    enabledServices: {} as IEnabledServices,
 };
 
 // slice
@@ -41,6 +36,9 @@ const navigationSlice = createSlice({
         },
         setActiveHref (state, action: PayloadAction<string>) {
             state.activeHref = action.payload;
+        },
+        setEnabledServices (state, action: PayloadAction<IEnabledServices>) {
+            state.enabledServices = action.payload;
         },
         setAdminItems (state, action: PayloadAction<boolean>) {
             if (action.payload) {
@@ -58,10 +56,10 @@ const navigationSlice = createSlice({
                 state.adminItems = undefined;
             }
         },
-        setItemsForProjectName (state, action: PayloadAction<NavigationReducerState>) {
-            const projectName = action.payload.project;
+        setItemsForProjectName (state, action: PayloadAction<string | undefined>) {
+            const projectName = action.payload;
             if (projectName) {
-                const translateItems: any = action.payload.enabledServices.batchTranslate
+                const translateItems: any = state.enabledServices.batchTranslate
                     ? [
                         {
                             type: 'section',
@@ -78,7 +76,7 @@ const navigationSlice = createSlice({
                     ]
                     : [];
 
-                const groundTruthItems: any = action.payload.enabledServices.labelingJob
+                const groundTruthItems: any = state.enabledServices.labelingJob
                     ? [
                         {
                             type: 'section',
@@ -111,7 +109,7 @@ const navigationSlice = createSlice({
                                 text: 'Datasets',
                                 href: `#/project/${projectName}/dataset`,
                             },
-                            ...action.payload.enabledServices.emrCluster ? [{
+                            ...state.enabledServices.emrCluster ? [{
                                 type: 'link',
                                 text: 'EMR clusters',
                                 href: `#/project/${projectName}/emr`,
@@ -174,6 +172,6 @@ const navigationSlice = createSlice({
 });
 
 // Reducer
-export const { setBreadcrumbs, setActiveHref, setItemsForProjectName, setAdminItems } =
+export const { setBreadcrumbs, setActiveHref, setItemsForProjectName, setAdminItems, setEnabledServices } =
     navigationSlice.actions;
 export default navigationSlice.reducer;

--- a/frontend/src/shared/layout/navigation/navigation.reducer.ts
+++ b/frontend/src/shared/layout/navigation/navigation.reducer.ts
@@ -58,10 +58,10 @@ const navigationSlice = createSlice({
                 state.adminItems = undefined;
             }
         },
-        setItemsForProjectName (state, action: PayloadAction<NavigationReducerState | undefined>) {
-            const projectName = action.payload?.project;
+        setItemsForProjectName (state, action: PayloadAction<NavigationReducerState>) {
+            const projectName = action.payload.project;
             if (projectName) {
-                const translateItems: any = action.payload?.enabledServices?.batchTranslate
+                const translateItems: any = action.payload.enabledServices.batchTranslate
                     ? [
                         {
                             type: 'section',
@@ -78,7 +78,7 @@ const navigationSlice = createSlice({
                     ]
                     : [];
 
-                const groundTruthItems: any = action.payload?.enabledServices?.labelingJob
+                const groundTruthItems: any = action.payload.enabledServices.labelingJob
                     ? [
                         {
                             type: 'section',
@@ -111,7 +111,7 @@ const navigationSlice = createSlice({
                                 text: 'Datasets',
                                 href: `#/project/${projectName}/dataset`,
                             },
-                            ...action.payload?.enabledServices?.emrCluster ? [{
+                            ...action.payload.enabledServices.emrCluster ? [{
                                 type: 'link',
                                 text: 'EMR clusters',
                                 href: `#/project/${projectName}/emr`,

--- a/frontend/src/shared/layout/navigation/navigation.reducer.ts
+++ b/frontend/src/shared/layout/navigation/navigation.reducer.ts
@@ -51,10 +51,10 @@ const navigationSlice = createSlice({
                 state.adminItems = undefined;
             }
         },
-        setItemsForProjectName (state, action: PayloadAction<string | undefined>) {
-            const projectName = action.payload;
+        setItemsForProjectName (state, action: PayloadAction<any | undefined>) {
+            const projectName = action.payload?.project;
             if (projectName) {
-                const translateItems: any = window.env.ENABLE_TRANSLATE
+                const translateItems: any = action.payload?.enabledServices?.batchTranslate
                     ? [
                         {
                             type: 'section',
@@ -71,7 +71,7 @@ const navigationSlice = createSlice({
                     ]
                     : [];
 
-                const groundTruthItems: any = window.env.ENABLE_GROUNDTRUTH
+                const groundTruthItems: any = action.payload?.enabledServices?.labelingJob
                     ? [
                         {
                             type: 'section',
@@ -104,11 +104,11 @@ const navigationSlice = createSlice({
                                 text: 'Datasets',
                                 href: `#/project/${projectName}/dataset`,
                             },
-                            {
+                            ...action.payload?.enabledServices?.emrCluster ? [{
                                 type: 'link',
                                 text: 'EMR clusters',
                                 href: `#/project/${projectName}/emr`,
-                            },
+                            }] : [],
                             {
                                 type: 'section',
                                 text: 'Inference',

--- a/frontend/src/shared/layout/navigation/side-navigation.tsx
+++ b/frontend/src/shared/layout/navigation/side-navigation.tsx
@@ -152,7 +152,7 @@ export default function SideNavigation () {
                         selectedOption={selectedOption}
                         onChange={({ detail }) => {
                             setSelectedOption(detail.selectedOption);
-                            dispatch(setItemsForProjectName(detail.selectedOption.value));
+                            dispatch(setItemsForProjectName({ 'project': detail.selectedOption.value, 'enabledServices': applicationConfig.configuration.EnabledServices }));
                             navigate(`/project/${detail.selectedOption.value}`);
                         }}
                         options={projectOptions}

--- a/frontend/src/shared/layout/navigation/side-navigation.tsx
+++ b/frontend/src/shared/layout/navigation/side-navigation.tsx
@@ -23,7 +23,7 @@ import {
     FormField
 } from '@cloudscape-design/components';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
-import { setActiveHref, setItemsForProjectName } from './navigation.reducer';
+import {setActiveHref, setItemsForProjectName} from './navigation.reducer';
 import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 import { IProject } from '../../model/project.model';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -152,7 +152,7 @@ export default function SideNavigation () {
                         selectedOption={selectedOption}
                         onChange={({ detail }) => {
                             setSelectedOption(detail.selectedOption);
-                            dispatch(setItemsForProjectName({ 'project': detail.selectedOption.value, 'enabledServices': applicationConfig.configuration.EnabledServices }));
+                            dispatch(setItemsForProjectName(detail.selectedOption.value));
                             navigate(`/project/${detail.selectedOption.value}`);
                         }}
                         options={projectOptions}


### PR DESCRIPTION
AIML-ADC-8599

Updating the FE to follow the Dynamo config for enabled/disabled services. This includes services displayed in the side nav, project detail section, and URLs we are allowed to navigate to.

Attached are screenshots with all services enabled, all services disabled, and a demonstration navigating to the blocked Batch Translate URLs. 

<img width="1684" alt="All Services Enabled" src="https://github.com/awslabs/mlspace/assets/14100972/63dc6f7a-8b3c-4a9b-a18a-7d5cb89cd526">

<img width="1684" alt="All Services Disabled" src="https://github.com/awslabs/mlspace/assets/14100972/a26d3f01-9b37-4fd9-9d7d-0f019373fcf2">

![demo](https://github.com/awslabs/mlspace/assets/14100972/2ee235d4-1e19-46be-946d-2c0f4ec67e0d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
