### PR TITLE
Updated instance types to allowlist instead of blocklist

### DIFF
--- a/backend/src/ml_space_lambda/data_access_objects/app_configuration.py
+++ b/backend/src/ml_space_lambda/data_access_objects/app_configuration.py
@@ -68,13 +68,13 @@ class AppConfigurationModel:
 class SettingsModel:
     def __init__(
         self,
-        disabled_instance_types: ServiceInstanceTypes,
+        enabled_instance_types: ServiceInstanceTypes,
         enabled_services: EnabledServices,
         emr_config: EMRConfig,
         project_creation: Optional[ProjectCreation] = None,
         system_banner: Optional[SystemBanner] = None,
     ):
-        self.disabled_instance_types = disabled_instance_types
+        self.enabled_instance_types = enabled_instance_types
         self.enabled_services = enabled_services
         self.project_creation = project_creation
         self.emr_config = emr_config
@@ -82,7 +82,7 @@ class SettingsModel:
 
     def to_dict(self) -> dict:
         config_dict = {
-            "DisabledInstanceTypes": self.disabled_instance_types.to_dict(),
+            "EnabledInstanceTypes": self.enabled_instance_types.to_dict(),
             "EnabledServices": self.enabled_services.to_dict(),
             "EMRConfig": self.emr_config.to_dict(),
         }
@@ -97,7 +97,7 @@ class SettingsModel:
     @staticmethod
     def from_dict(dict_object: dict) -> SettingsModel:
         return SettingsModel(
-            disabled_instance_types=ServiceInstanceTypes.from_dict(dict_object["DisabledInstanceTypes"]),
+            enabled_instance_types=ServiceInstanceTypes.from_dict(dict_object["EnabledInstanceTypes"]),
             enabled_services=EnabledServices.from_dict(dict_object["EnabledServices"]),
             emr_config=EMRConfig.from_dict(dict_object["EMRConfig"]),
             project_creation=(

--- a/backend/test/app_configuration/test_update_configuration.py
+++ b/backend/test/app_configuration/test_update_configuration.py
@@ -44,7 +44,7 @@ def generate_event(config_scope: str, version_id: int):
                 "changeReason": "Testing",
                 "createdAt": mock_time,
                 "configuration": {
-                    "DisabledInstanceTypes": {
+                    "EnabledInstanceTypes": {
                         ServiceType.NOTEBOOK.value: ["ml.t3.medium", "ml.r5.large"],
                         ServiceType.ENDPOINT.value: ["ml.t3.large", "ml.r5.medium"],
                         ServiceType.TRAINING_JOB.value: ["ml.t3.xlarge", "ml.r5.small"],

--- a/backend/test/authorizer/test_authorizer.py
+++ b/backend/test/authorizer/test_authorizer.py
@@ -143,7 +143,7 @@ def generate_test_config(config_scope: str = "global", is_project: bool = False,
         "changedBy": "Tester",
         "createdAt": 1,
         "configuration": {
-            "DisabledInstanceTypes": {
+            "EnabledInstanceTypes": {
                 ServiceType.NOTEBOOK.value: [],
                 ServiceType.ENDPOINT.value: [],
                 ServiceType.TRAINING_JOB.value: [],

--- a/backend/test/data_access_objects/test_app_configuration.py
+++ b/backend/test/data_access_objects/test_app_configuration.py
@@ -62,7 +62,7 @@ def generate_test_config(config_scope: str, version_id: int, is_project: bool) -
         "changedBy": "Tester",
         "createdAt": mock_time,
         "configuration": {
-            "DisabledInstanceTypes": {
+            "EnabledInstanceTypes": {
                 ServiceType.NOTEBOOK.value: ["ml.t3.medium", "ml.r5.large"],
                 ServiceType.ENDPOINT.value: ["ml.t3.large", "ml.r5.medium"],
                 ServiceType.TRAINING_JOB.value: ["ml.t3.xlarge", "ml.r5.small"],

--- a/backend/test/emr/test_create_emr_cluster.py
+++ b/backend/test/emr/test_create_emr_cluster.py
@@ -53,7 +53,7 @@ MOCK_APP_CONFIG = {
     "changedBy": "Tester",
     "createdAt": 1,
     "configuration": {
-        "DisabledInstanceTypes": {
+        "EnabledInstanceTypes": {
             ServiceType.NOTEBOOK.value: [],
             ServiceType.ENDPOINT.value: [],
             ServiceType.TRAINING_JOB.value: [],

--- a/frontend/src/shared/model/app.configuration.model.ts
+++ b/frontend/src/shared/model/app.configuration.model.ts
@@ -78,7 +78,7 @@ export type ISystemBanner = {
 };
 
 export type BaseSettings = {
-    DisabledInstanceTypes: IServiceInstanceTypes;
+    EnabledInstanceTypes: IServiceInstanceTypes;
     EnabledServices: IEnabledServices;
     EMRConfig: IEMRConfig;
 };
@@ -107,7 +107,7 @@ export const defaultConfiguration: IAppConfiguration = {
     changedBy: '',
     changeReason: '',
     configuration: {
-        DisabledInstanceTypes: {
+        EnabledInstanceTypes: {
             notebook: [],
             endpoint: [],
             trainingJob: [],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After our discussion this morning we decided we wanted to use an allow list instead of a block list. Updating the model to reflect EnabledInstanceTypes instead of DiabledInstancedTypes now makes more sense.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
