### PR TITLE
[AIML-ADC-9143] Allow users to fetch app config without authenticating

### DIFF
--- a/lib/utils/apiFunction.ts
+++ b/lib/utils/apiFunction.ts
@@ -40,10 +40,9 @@ export type MLSpacePythonLambdaFunction = {
     };
 };
 
-export function registerAPIEndpoint (
+function registerEndpoint (
     stack: Stack,
     api: IRestApi,
-    authorizer: IAuthorizer,
     role: IRole,
     notebookRoleName: string,
     lambdaSourcePath: string,
@@ -52,6 +51,7 @@ export function registerAPIEndpoint (
     vpc: IVpc,
     securityGroups: ISecurityGroup[],
     mlspaceConfig: MLSpaceConfig,
+    authorizer?: IAuthorizer,
     permissionsBoundaryArn?: string,
 ) {
     const functionId = `mls-lambda-${funcDef.id || [funcDef.resource, funcDef.name].join('-')}`;
@@ -90,6 +90,67 @@ export function registerAPIEndpoint (
         authorizationType: AuthorizationType.CUSTOM,
     });
 }
+
+export function registerAPIEndpoint (
+    stack: Stack,
+    api: IRestApi,
+    authorizer: IAuthorizer,
+    role: IRole,
+    notebookRoleName: string,
+    lambdaSourcePath: string,
+    layers: ILayerVersion[],
+    funcDef: MLSpacePythonLambdaFunction,
+    vpc: IVpc,
+    securityGroups: ISecurityGroup[],
+    mlspaceConfig: MLSpaceConfig,
+    permissionsBoundaryArn?: string,
+) {
+    registerEndpoint(
+        stack,
+        api,
+        role,
+        notebookRoleName,
+        lambdaSourcePath,
+        layers,
+        funcDef,
+        vpc,
+        securityGroups,
+        mlspaceConfig,
+        authorizer,
+        permissionsBoundaryArn
+    );
+}
+
+export function registerUnauthenticatedEndpoint (
+    stack: Stack,
+    api: IRestApi,
+    role: IRole,
+    notebookRoleName: string,
+    lambdaSourcePath: string,
+    layers: ILayerVersion[],
+    funcDef: MLSpacePythonLambdaFunction,
+    vpc: IVpc,
+    securityGroups: ISecurityGroup[],
+    mlspaceConfig: MLSpaceConfig,
+    permissionsBoundaryArn?: string,
+) {
+    registerEndpoint(
+        stack,
+        api,
+        role,
+        notebookRoleName,
+        lambdaSourcePath,
+        layers,
+        funcDef,
+        vpc,
+        securityGroups,
+        mlspaceConfig,
+        undefined,
+        permissionsBoundaryArn
+    );
+}
+
+
 
 function getOrCreateResource (stack: Stack, parentResource: IResource, path: string[]): IResource {
     let resource = parentResource.getResource(path[0]);


### PR DESCRIPTION
*Issue #, if available:*
AIML-ADC-9143
*Description of changes:*
While we updated to authorizer to allow users to fetch the application config without checking on their token we still had the authorizer associated with the resource. Unauthenticated users are missing a header required by the authorizer so we were returning a 401 before we even hit the lambda. This change adds support for registering 'unauthenticated' endpoints and uses that for the GET app-config resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
