### PR TITLE
Compute type fix

### DIFF
--- a/frontend/src/shared/metadata/instance-type-dropdown.tsx
+++ b/frontend/src/shared/metadata/instance-type-dropdown.tsx
@@ -114,12 +114,6 @@ export function InstanceTypeSelector (props: InstanceTypeSelectorProperties) {
         computeTypes.status,
         dispatch,
     ]);
-      
-    useEffect(() => {
-        if (computeTypes.status === LoadingStatus.INITIAL) {
-            dispatch(listComputeTypes());
-        }
-    }, [dispatch, computeTypes.status]);
 
     return (
         <Select

--- a/frontend/src/shared/metadata/instance-type-dropdown.tsx
+++ b/frontend/src/shared/metadata/instance-type-dropdown.tsx
@@ -99,9 +99,21 @@ export function InstanceTypeSelector (props: InstanceTypeSelectorProperties) {
         if (props.service) {
             return getInstanceTypes(applicationConfig.configuration.EnabledInstanceTypes[props.service]);
         } else {
-            return getInstanceTypes(computeTypes.values.InstanceTypes['InstanceType']);
+            if (computeTypes.status === LoadingStatus.INITIAL) {
+                dispatch(listComputeTypes());
+                return [];
+            }
+            if (computeTypes.status === LoadingStatus.FULFILLED) {
+                return getInstanceTypes(computeTypes.values.InstanceTypes['InstanceType']);
+            }
         }
-    }, [props, applicationConfig.configuration.EnabledInstanceTypes, computeTypes.values.InstanceTypes]);
+    }, [
+        props, 
+        applicationConfig.configuration.EnabledInstanceTypes, 
+        computeTypes.values.InstanceTypes,
+        computeTypes.status,
+        dispatch,
+    ]);
       
     useEffect(() => {
         if (computeTypes.status === LoadingStatus.INITIAL) {


### PR DESCRIPTION
*Description of changes:* Return an empty list while waiting for computeTypes to load.

The selector should be in a "loading" state anyways due to this line:
```
statusType={props.service || computeTypes.status === LoadingStatus.FULFILLED ? 'finished' : 'loading'}
```

But this is to prevent any kind of null references and make sure we're only using the `getInstanceTypes` function when computeTypes is ready.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
