### PR TITLE
Fix issue introduced in previous commit with registerUnauthenticatedEndpoint

### DIFF
--- a/lib/utils/apiFunction.ts
+++ b/lib/utils/apiFunction.ts
@@ -85,7 +85,7 @@ function registerEndpoint (
         securityGroups,
     });
     const functionResource = getOrCreateResource(stack, api.root, funcDef.path.split('/'));
-    functionResource.addMethod(funcDef.method, new LambdaIntegration(handler), {
+    functionResource.addMethod(funcDef.method, new LambdaIntegration(handler), authorizer && {
         authorizer,
         authorizationType: AuthorizationType.CUSTOM,
     });


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Specifying an `authorizationType` without specifying an `authorizer` when adding an api gateway resource is not supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
