### PR TITLE
Allow prefix selection for batch translate input

### DIFF
--- a/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
+++ b/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
@@ -333,7 +333,7 @@ export function BatchTranslateCreate () {
                     <Container header={<Header variant='h2'>Input data</Header>}>
                         <DatasetResourceSelector
                             fieldLabel={'S3 Location'}
-                            selectableItemsTypes={['objects']}
+                            selectableItemsTypes={['objects', 'prefixes']}
                             onChange={({detail}) => {
                                 setFields({
                                     'InputDataConfig.S3Uri': detail.resource,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows selecting prefixes in addition to objects in the Batch Translate DatasetSelector component.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
