### PR TITLE
Fixes lowercase typo in initial app configuration

### DIFF
--- a/lib/utils/initialAppConfig.ts
+++ b/lib/utils/initialAppConfig.ts
@@ -86,7 +86,7 @@ export function generateAppConfig (mlspaceConfig: MLSpaceConfig) {
     // This may not be set in the user's cluster-config (if it existed)
     if (clusterConfig['applications']) {
         for (const application of clusterConfig['applications']) {
-            applicationList.push({'M': {'name': {'S': application['Name']}}});
+            applicationList.push({'M': {'Name': {'S': application['Name']}}});
         }
     }
     const clusterTypes = [];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The initial app configuration was creating EMR applications with `name` as the key in DDB even though throughout the code it expects applications with `Name` as the key.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
