### PR TITLE
fix default value of modal input field to be the form change reason

### DIFF
--- a/frontend/src/entities/configuration/configuration-history-table.tsx
+++ b/frontend/src/entities/configuration/configuration-history-table.tsx
@@ -35,7 +35,8 @@ export function ConfigurationHistoryTable () {
 
     useMemo(() => {
         dispatch(listConfigurations({configScope: 'global', numVersions: 10}));
-    }, [dispatch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dispatch, applicationConfig]);
 
     const columnDefinition = [
         {

--- a/frontend/src/entities/configuration/dynamic-configuration.tsx
+++ b/frontend/src/entities/configuration/dynamic-configuration.tsx
@@ -316,10 +316,9 @@ export function DynamicConfiguration () {
                         label='Change reason'
                     >
                         <Input
-                            value={`Changes to: ${Object.keys(changesDiff)}`}
+                            value={_.isEqual(state.form.changeReason, applicationConfig.changeReason) ? `Changes to: ${Object.keys(changesDiff)}` : state.form.changeReason}
                             onChange={(event) => {
                                 setFields({ 'changeReason': event.detail.value });
-                                console.log(state.form);
                             }}
                             disabled={_.isEmpty(changesDiff)}
                         />

--- a/frontend/src/entities/configuration/dynamic-configuration.tsx
+++ b/frontend/src/entities/configuration/dynamic-configuration.tsx
@@ -318,7 +318,7 @@ export function DynamicConfiguration () {
                         label='Change reason'
                     >
                         <Input
-                            value={_.isEqual(state.form.changeReason, applicationConfig.changeReason) ? `Changes to: ${Object.keys(changesDiff)}` : state.form.changeReason}
+                            value={state.form.changeReason}
                             onChange={(event) => {
                                 setFields({ 'changeReason': event.detail.value });
                             }}
@@ -665,6 +665,7 @@ export function DynamicConfiguration () {
                         iconAlt='Update dynamic configuration'
                         variant='primary'
                         onClick={() => {
+                            setFields({ 'changeReason': `Changes to: ${Object.keys(changesDiff)}` });
                             setModalVisible(true);
                         }}
                         loading={state.formSubmitting}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix for two different bugs:
- Updating the configuration was not updating the configuration table histroy automatically.
- When saving changes in admin config, the expected changeReason is now set


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
