### PR TITLE
Add config history table pagination, filtering, and sorting

### DIFF
--- a/frontend/src/entities/configuration/configuration-history-table.tsx
+++ b/frontend/src/entities/configuration/configuration-history-table.tsx
@@ -35,8 +35,8 @@ export function ConfigurationHistoryTable () {
     });
 
     useMemo(() => {
-        dispatch(listConfigurations({configScope: 'global', numVersions: 999999}));
-    }, [dispatch]);
+        dispatch(listConfigurations({configScope: 'global', numVersions: applicationConfig.versionId + 1}));
+    }, [applicationConfig.versionId, dispatch]);
 
     const columnDefinition = [
         {

--- a/frontend/src/entities/configuration/configuration-history-table.tsx
+++ b/frontend/src/entities/configuration/configuration-history-table.tsx
@@ -18,7 +18,8 @@ import React, { useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from '../../config/store';
 import { IAppConfiguration, defaultConfiguration } from '../../shared/model/app.configuration.model';
 import { appConfig, appConfigList, getConfiguration, listConfigurations, loadingAppConfigList, updateConfiguration } from './configuration-reducer';
-import { Box, Button, FormField, Header, Input, Modal, SpaceBetween, Table } from '@cloudscape-design/components';
+import { Box, Button, FormField, Header, Input, Modal, SpaceBetween } from '@cloudscape-design/components';
+import Table from '../../modules/table';
 import NotificationService from '../../shared/layout/notification/notification.service';
 
 export function ConfigurationHistoryTable () {
@@ -34,20 +35,23 @@ export function ConfigurationHistoryTable () {
     });
 
     useMemo(() => {
-        dispatch(listConfigurations({configScope: 'global', numVersions: 10}));
+        dispatch(listConfigurations({configScope: 'global', numVersions: 999999}));
     }, [dispatch]);
 
     const columnDefinition = [
         {
             header: 'Version',
+            sortingField: 'versionId',
             cell: (item) => item.versionId,
         },
         {
             header: 'Changed by',
+            sortingField: 'changedBy',
             cell: (item) => item.changedBy,
         },
         {
             header: 'Change reason',
+            sortingField: 'changeReason',
             cell: (item) => item.changeReason,
         },
         {
@@ -59,11 +63,12 @@ export function ConfigurationHistoryTable () {
     return (
         <>
             <Table
-                header={<Header> Configuration history </Header>}
+                tableName='Configuration history'
+                tableType='single'
+                itemNameProperty='versionId'
+                trackBy='versionId'
+                allItems={configList}
                 columnDefinitions={columnDefinition}
-                items={configList}
-                loading={loadingConfigList}
-                loadingText='Loading configurations'
             />
 
             <Modal 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Add pagination, filtering, and sorting to config table

![Recording 2024-06-11 at 12 26 14](https://github.com/awslabs/mlspace/assets/28429388/d418ac17-6211-4dc2-abfe-3016a508b0c3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
