### PR TITLE
Hotfix for emr release labels

### DIFF
--- a/frontend/src/entities/emr/create/emr-cluster-create.tsx
+++ b/frontend/src/entities/emr/create/emr-cluster-create.tsx
@@ -97,7 +97,7 @@ export default function EMRClusterCreate () {
             options: {
                 customAmiId: '',
                 emrSize: 'Small',
-                emrRelease: releaseLabels[0],
+                emrRelease: releaseLabels ? releaseLabels[0] : '',
             },
             Instances: {
                 Ec2SubnetId: ''
@@ -279,7 +279,7 @@ export default function EMRClusterCreate () {
                                             'options.emrRelease': detail.selectedOption.value,
                                         });
                                     }}
-                                    options={releaseLabels.map((release) => {
+                                    options={releaseLabels?.map((release) => {
                                         return {
                                             value: release,
                                         };

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -796,7 +796,11 @@ export class IAMStack extends Stack {
                  */
                 new PolicyStatement({
                     effect: Effect.ALLOW,
-                    actions: ['elasticmapreduce:RunJobFlow', 'elasticmapreduce:ListClusters'],
+                    actions: [
+                        'elasticmapreduce:RunJobFlow', 
+                        'elasticmapreduce:ListClusters',
+                        'elasticmapreduce:ListReleaseLabels'
+                    ],
                     resources: ['*'],
                 }),
                 // EMR Permissions


### PR DESCRIPTION
*Description of changes:* Currently on main it is not possible to create EMR clusters or to get to the form because of breaking issues:
- `elasticmapreduce:ListReleaseLabels` permission was accidentally removed from the `iam` stack
- When running locally it wasn't necessary for `releaseLabels` to be optional, but it was observed that this didn't work on a deployed version. The page failed before the dispatch for release labels occurred.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
