### PR TITLE
restore high contrast header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,6 +65,7 @@ export default function App () {
                         toolsClose: 'Close help panel',
                         toolsToggle: 'Open help panel',
                     }}
+                    headerVariant='high-contrast'
                     contentHeader={<Header />}
                     headerSelector='#topBanner'
                     footerSelector='#bottomBanner'

--- a/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
+++ b/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
@@ -24,7 +24,6 @@ import {
     FormField,
     Input,
     Container,
-    ContentLayout,
     Select,
     Multiselect,
     Toggle,
@@ -57,6 +56,7 @@ import '../../../shared/validation/helpers/uri';
 import { datasetFromS3Uri } from '../../../shared/util/dataset-utils';
 import { isFulfilled } from '@reduxjs/toolkit';
 import { AUTO_SOURCE_LANGUAGE_UNSUPPORTED } from '..';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 export function BatchTranslateCreate () {
     const [errorText] = useState('');

--- a/frontend/src/entities/batch-translate/detail/batch-translate-detail.tsx
+++ b/frontend/src/entities/batch-translate/detail/batch-translate-detail.tsx
@@ -18,7 +18,6 @@ import { useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import React, { ReactNode, useEffect, useState } from 'react';
 import {
-    ContentLayout,
     SpaceBetween,
     Header,
     Button,
@@ -41,6 +40,7 @@ import NotificationService from '../../../shared/layout/notification/notificatio
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { getDownloadUrl } from '../../dataset/dataset.service';
 import { useBackgroundRefresh } from '../../../shared/util/hooks';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function BatchTranslateDetail () {
     const { projectName, jobId } = useParams();

--- a/frontend/src/entities/configuration/activated-services-configuration.tsx
+++ b/frontend/src/entities/configuration/activated-services-configuration.tsx
@@ -17,7 +17,6 @@
 import {
     Alert,
     Container,
-    ContentLayout,
     Grid,
     Header,
     SpaceBetween,
@@ -26,6 +25,7 @@ import {
 } from '@cloudscape-design/components';
 import React from 'react';
 import {SetFieldsFunction} from '../../shared/validation';
+import ContentLayout from '../../shared/layout/content-layout';
 
 const configurableServices = {
     batchTranslate: 'Amazon Translate batch',

--- a/frontend/src/entities/configuration/activated-services-configuration.tsx
+++ b/frontend/src/entities/configuration/activated-services-configuration.tsx
@@ -25,7 +25,6 @@ import {
 } from '@cloudscape-design/components';
 import React from 'react';
 import {SetFieldsFunction} from '../../shared/validation';
-import ContentLayout from '../../shared/layout/content-layout';
 
 const configurableServices = {
     batchTranslate: 'Amazon Translate batch',
@@ -47,36 +46,34 @@ export function ActivatedServicesConfiguration (props: ActivatedServicesConfigur
                     Activated Services
                 </Header>
             }>
-            <ContentLayout>
-                <SpaceBetween direction='vertical' size='m'>
-                    <Alert statusIconAriaLabel='Info'>Activated Services: Activate or deactivate services
+            <SpaceBetween direction='vertical' size='m'>
+                <Alert statusIconAriaLabel='Info'>Activated Services: Activate or deactivate services
                         within MLSpace. IAM permissions that control access to these services within the
                         MLSpace user interface and Jupyter Notebooks will automatically update. Deactivated
                         services will no longer appear within the MLSpace user interface. Deactivating
                         services will terminate all active corresponding jobs and instances associated with
                         the service.</Alert>
-                    <Grid gridDefinition={Object.keys(configurableServices).map(() => ({colspan: 3}))}>
-                        {Object.keys(configurableServices).map((service) => {
-                            return (
-                                <Box textAlign='center'>
-                                    <SpaceBetween alignItems='center' size='xs'>
-                                        <Toggle
-                                            onChange={({detail}) => {
-                                                const updatedField = {};
-                                                updatedField[`configuration.EnabledServices.${service}`] = detail.checked;
-                                                props.setFields(updatedField);
-                                            }}
-                                            checked={props.enabledServices[service]}
-                                        >
-                                        </Toggle>
-                                    </SpaceBetween>
-                                    <p>{configurableServices[service]}</p>
-                                </Box>
-                            );
-                        })}
-                    </Grid>
-                </SpaceBetween>
-            </ContentLayout>
+                <Grid gridDefinition={Object.keys(configurableServices).map(() => ({colspan: 3}))}>
+                    {Object.keys(configurableServices).map((service) => {
+                        return (
+                            <Box textAlign='center'>
+                                <SpaceBetween alignItems='center' size='xs'>
+                                    <Toggle
+                                        onChange={({detail}) => {
+                                            const updatedField = {};
+                                            updatedField[`configuration.EnabledServices.${service}`] = detail.checked;
+                                            props.setFields(updatedField);
+                                        }}
+                                        checked={props.enabledServices[service]}
+                                    >
+                                    </Toggle>
+                                </SpaceBetween>
+                                <p>{configurableServices[service]}</p>
+                            </Box>
+                        );
+                    })}
+                </Grid>
+            </SpaceBetween>
         </Container>
     );
 }

--- a/frontend/src/entities/configuration/configuration.tsx
+++ b/frontend/src/entities/configuration/configuration.tsx
@@ -66,13 +66,13 @@ export function Configuration () {
                             label: 'Dynamic Configuration',
                             id: 'dynamic-config',
                             content: <DynamicConfiguration/>,
-                            disabled: false
+                            disabled: true
                         },
                         {
                             label: 'Dynamic Configuration History',
                             id: 'config-hist',
                             content: <ConfigurationHistoryTable/>,
-                            disabled: false
+                            disabled: true
                         },
                         {
                             label: 'Deployment Configuration',

--- a/frontend/src/entities/configuration/configuration.tsx
+++ b/frontend/src/entities/configuration/configuration.tsx
@@ -19,7 +19,6 @@ import { setBreadcrumbs } from '../../shared/layout/navigation/navigation.reduce
 import { useAppDispatch } from '../../config/store';
 import {
     Header,
-    SpaceBetween,
     Tabs
 } from '@cloudscape-design/components';
 import React, { useEffect } from 'react';
@@ -29,6 +28,7 @@ import DeploymentConfiguration from './deployment-configuration';
 import DynamicConfiguration from './dynamic-configuration';
 import { ConfigurationHistoryTable } from './configuration-history-table';
 import ContentLayout from '../../shared/layout/content-layout';
+import { borderRadiusContainer, colorBackgroundContainerContent } from '@cloudscape-design/design-tokens';
 
 export function Configuration () {
     const dispatch = useAppDispatch();
@@ -59,30 +59,28 @@ export function Configuration () {
                 </Header>
             }
         >
-            <SpaceBetween direction='vertical' size='xl'>
+            <div style={{ borderRadius: borderRadiusContainer, background: colorBackgroundContainerContent, padding: '5px' }}>
                 <Tabs
                     tabs={[
                         {
                             label: 'Dynamic Configuration',
                             id: 'dynamic-config',
-                            content: <DynamicConfiguration/>,
-                            disabled: true
+                            content: <DynamicConfiguration />,
                         },
                         {
                             label: 'Dynamic Configuration History',
                             id: 'config-hist',
-                            content: <ConfigurationHistoryTable/>,
-                            disabled: true
+                            content: <ConfigurationHistoryTable />,
                         },
                         {
                             label: 'Deployment Configuration',
                             id: 'deployment-config',
-                            content: <DeploymentConfiguration/>
+                            content: <DeploymentConfiguration />
                         },
                     ]}
                 />
-            </SpaceBetween>
-            
+            </div>
+
         </ContentLayout>
     );
 }

--- a/frontend/src/entities/configuration/configuration.tsx
+++ b/frontend/src/entities/configuration/configuration.tsx
@@ -19,7 +19,6 @@ import { setBreadcrumbs } from '../../shared/layout/navigation/navigation.reduce
 import { useAppDispatch } from '../../config/store';
 import {
     Header,
-    ContentLayout,
     SpaceBetween,
     Tabs
 } from '@cloudscape-design/components';
@@ -29,6 +28,7 @@ import { useParams } from 'react-router-dom';
 import DeploymentConfiguration from './deployment-configuration';
 import DynamicConfiguration from './dynamic-configuration';
 import { ConfigurationHistoryTable } from './configuration-history-table';
+import ContentLayout from '../../shared/layout/content-layout';
 
 export function Configuration () {
     const dispatch = useAppDispatch();
@@ -66,13 +66,13 @@ export function Configuration () {
                             label: 'Dynamic Configuration',
                             id: 'dynamic-config',
                             content: <DynamicConfiguration/>,
-                            disabled: true
+                            disabled: false
                         },
                         {
                             label: 'Dynamic Configuration History',
                             id: 'config-hist',
                             content: <ConfigurationHistoryTable/>,
-                            disabled: true
+                            disabled: false
                         },
                         {
                             label: 'Deployment Configuration',

--- a/frontend/src/entities/dataset/create/dataset-create.tsx
+++ b/frontend/src/entities/dataset/create/dataset-create.tsx
@@ -25,7 +25,6 @@ import {
     Input,
     Container,
     Select,
-    ContentLayout,
     Popover,
     StatusIndicator,
     Alert,
@@ -52,6 +51,7 @@ import { DatasetBrowserManageMode } from '../../../modules/dataset/dataset-brows
 import { DatasetResourceObject } from '../../../modules/dataset/dataset-browser.reducer';
 import NotificationService from '../../../shared/layout/notification/notification.service';
 import { useUsername } from '../../../shared/util/auth-utils';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 const formSchema = z.object({
     name: z

--- a/frontend/src/entities/dataset/detail/dataset-detail.tsx
+++ b/frontend/src/entities/dataset/detail/dataset-detail.tsx
@@ -17,7 +17,6 @@
 import React, { ReactNode, useEffect } from 'react';
 import {
     Container,
-    ContentLayout,
     SpaceBetween,
     Header,
     Button,
@@ -39,6 +38,7 @@ import DetailsContainer from '../../../modules/details-container';
 import DatasetBrowser from '../../../modules/dataset/dataset-browser';
 import { DatasetBrowserActions } from '../dataset.actions';
 import { DatasetBrowserManageMode } from '../../../modules/dataset/dataset-browser.types';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function DatasetDetail () {
     const { projectName, scope, name } = useParams();

--- a/frontend/src/entities/dataset/update/dataset-update.tsx
+++ b/frontend/src/entities/dataset/update/dataset-update.tsx
@@ -23,10 +23,10 @@ import {
     Header,
     FormField,
     Container,
-    ContentLayout,
     StatusIndicator,
     Textarea,
     Input,
+    ContentLayout,
 } from '@cloudscape-design/components';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';

--- a/frontend/src/entities/emr/create/emr-cluster-create.tsx
+++ b/frontend/src/entities/emr/create/emr-cluster-create.tsx
@@ -18,7 +18,6 @@ import React, { useEffect, useMemo } from 'react';
 import {
     Button,
     Container,
-    ContentLayout,
     ExpandableSection,
     Form,
     FormField,
@@ -46,6 +45,7 @@ import { Subnet } from '../../../shared/model/vpc.config';
 import { LoadingStatus } from '../../../shared/loading-status';
 import { ClusterType, IAppConfiguration } from '../../../shared/model/app.configuration.model';
 import { appConfig } from '../../configuration/configuration-reducer';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 enum ClusterAmi {
     BUILT_IN = 'built-in',

--- a/frontend/src/entities/emr/detail/emr-clusters-detail.tsx
+++ b/frontend/src/entities/emr/detail/emr-clusters-detail.tsx
@@ -17,7 +17,7 @@
 import { useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import React, { ReactNode, useEffect, useState } from 'react';
-import { ContentLayout, SpaceBetween, Header, Button } from '@cloudscape-design/components';
+import { SpaceBetween, Header, Button } from '@cloudscape-design/components';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
@@ -33,6 +33,7 @@ import { hasPermission } from '../../../shared/util/permission-utils';
 import { Permission } from '../../../shared/model/user.model';
 import { selectCurrentUser } from '../../user/user.reducer';
 import { useBackgroundRefresh } from '../../../shared/util/hooks';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function EMRDetail () {
     const { projectName, clusterId, clusterName } = useParams();

--- a/frontend/src/entities/endpoint-config/create/endpoint-config-create.tsx
+++ b/frontend/src/entities/endpoint-config/create/endpoint-config-create.tsx
@@ -24,7 +24,6 @@ import {
     FormField,
     Input,
     Container,
-    ContentLayout,
 } from '@cloudscape-design/components';
 import { useAppDispatch } from '../../../config/store';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
@@ -49,6 +48,7 @@ import { z } from 'zod';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { setTableAnnouncement } from '../../../shared/util/table-utils';
 import { generateNameConstraintText } from '../../../shared/util/form-utils';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 type EndpointConfigCreateOptions = {
     createConfigCallback?: (endpointConfig: IEndpointConfig, createdNew: boolean) => void;

--- a/frontend/src/entities/endpoint-config/detail/endpoint-config-detail.tsx
+++ b/frontend/src/entities/endpoint-config/detail/endpoint-config-detail.tsx
@@ -22,9 +22,10 @@ import { IEndpointConfig } from '../../../shared/model/endpoint-config.model';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Container, ContentLayout, Header, StatusIndicator } from '@cloudscape-design/components';
+import { Container, Header, StatusIndicator } from '@cloudscape-design/components';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { DocTitle } from '../../../../src/shared/doc';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function EndpointConfigDetail () {
     const { projectName, name } = useParams();

--- a/frontend/src/entities/endpoint/create/endpoint-create.tsx
+++ b/frontend/src/entities/endpoint/create/endpoint-create.tsx
@@ -25,7 +25,6 @@ import {
     Input,
     Container,
     Tiles,
-    ContentLayout,
     Alert,
 } from '@cloudscape-design/components';
 import { useAppDispatch } from '../../../config/store';
@@ -42,6 +41,7 @@ import { scrollToInvalid, useValidationState } from '../../../shared/validation'
 import { z } from 'zod';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { generateNameConstraintText } from '../../../shared/util/form-utils';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 export function EndpointCreate () {
     const [endpoint, setEndpoint] = useState(defaultEndpoint as IEndpoint);

--- a/frontend/src/entities/endpoint/detail/endpoint-detail.tsx
+++ b/frontend/src/entities/endpoint/detail/endpoint-detail.tsx
@@ -16,7 +16,6 @@
 
 import React, { ReactNode, useEffect, useState } from 'react';
 import {
-    ContentLayout,
     SpaceBetween,
     Header,
     Container,
@@ -48,6 +47,7 @@ import { selectCurrentUser } from '../../user/user.reducer';
 import { setResourceScheduleModal } from '../../../modules/modal/modal.reducer';
 import { modifyResourceTerminationSchedule } from '../../../shared/util/resource-schedule.service';
 import { useBackgroundRefresh } from '../../../shared/util/hooks';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function EndpointDetail () {
     const { projectName, name } = useParams();

--- a/frontend/src/entities/jobs/hpo/detail/hpo-job-detail.tsx
+++ b/frontend/src/entities/jobs/hpo/detail/hpo-job-detail.tsx
@@ -20,7 +20,6 @@ import {
     Button,
     ColumnLayout,
     Container,
-    ContentLayout,
     Grid,
     Header,
     SpaceBetween,
@@ -47,6 +46,7 @@ import { getBase } from '../../../../shared/util/breadcrumb-utils';
 import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
 import NotificationService from '../../../../shared/layout/notification/notification.service';
 import { useBackgroundRefresh } from '../../../../shared/util/hooks';
+import ContentLayout from '../../../../shared/layout/content-layout';
 
 export function HPOJobDetail () {
     const { projectName, jobName } = useParams();

--- a/frontend/src/entities/jobs/labeling/detail/labeling-job-detail.tsx
+++ b/frontend/src/entities/jobs/labeling/detail/labeling-job-detail.tsx
@@ -20,7 +20,6 @@ import {
     SpaceBetween,
     Header,
     Button,
-    ContentLayout,
     StatusIndicator,
 } from '@cloudscape-design/components';
 import React, { useEffect, ReactNode, useState } from 'react';
@@ -42,6 +41,7 @@ import { getLabelingJobType, getTotalLabelingObjectCount } from '../labeling-job
 import DetailsContainer from '../../../../modules/details-container';
 import { useBackgroundRefresh } from '../../../../shared/util/hooks';
 import { JobStatus } from '../../job.model';
+import ContentLayout from '../../../../shared/layout/content-layout';
 
 export function LabelingJobDetail () {
     const { projectName, jobName } = useParams();

--- a/frontend/src/entities/jobs/training/create/training-job-create.tsx
+++ b/frontend/src/entities/jobs/training/create/training-job-create.tsx
@@ -24,7 +24,6 @@ import {
     Grid,
     Button,
     Form,
-    ContentLayout,
     Header,
     AttributeEditor,
 } from '@cloudscape-design/components';
@@ -77,6 +76,7 @@ import { useUsername } from '../../../../shared/util/auth-utils';
 import '../../../../shared/validation/helpers/uri';
 import { datasetFromS3Uri } from '../../../../shared/util/dataset-utils';
 import { ServiceTypes } from '../../../../shared/model/app.configuration.model';
+import ContentLayout from '../../../../shared/layout/content-layout';
 
 const ALGORITHMS: { [key: string]: Algorithm } = {};
 ML_ALGORITHMS.filter((algorithm) => algorithm.defaultHyperParameters.length > 0).map(

--- a/frontend/src/entities/jobs/training/detail/training-job-detail.tsx
+++ b/frontend/src/entities/jobs/training/detail/training-job-detail.tsx
@@ -22,7 +22,6 @@ import {
     SpaceBetween,
     Header,
     Button,
-    ContentLayout,
     Table,
     StatusIndicator,
     Link,
@@ -48,6 +47,7 @@ import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
 import { LogsComponent } from '../../../../shared/util/log-utils';
 import { createModelFromTrainingJob } from '../training-job.actions';
 import { useBackgroundRefresh } from '../../../../shared/util/hooks';
+import ContentLayout from '../../../../shared/layout/content-layout';
 
 export function TrainingJobDetail () {
     const { projectName, trainingJobName } = useParams();

--- a/frontend/src/entities/jobs/transform/create/transform-create.tsx
+++ b/frontend/src/entities/jobs/transform/create/transform-create.tsx
@@ -28,7 +28,6 @@ import {
     Grid,
     ExpandableSection,
     SelectProps,
-    ContentLayout,
 } from '@cloudscape-design/components';
 import { AssembleWith, BatchStrategy, CompressionType, ITransform, S3DataType, SplitType, defaultValue } from '../../../../shared/model/transform.model';
 import { useAppDispatch, useAppSelector } from '../../../../config/store';
@@ -63,6 +62,7 @@ import DatasetResourceSelector from '../../../../modules/dataset/dataset-selecto
 import { datasetFromS3Uri } from '../../../../shared/util/dataset-utils';
 import { DatasetResourceSelectorSelectableItems } from '../../../../modules/dataset/dataset-selector.types';
 import { ServiceTypes } from '../../../../shared/model/app.configuration.model';
+import ContentLayout from '../../../../shared/layout/content-layout';
 
 export function TransformCreate () {
     const [s3DataTypes, setS3DataTypes] = useState([] as SelectProps.Option[]);

--- a/frontend/src/entities/jobs/transform/detail/transform-detail.tsx
+++ b/frontend/src/entities/jobs/transform/detail/transform-detail.tsx
@@ -22,7 +22,6 @@ import {
     Box,
     ColumnLayout,
     Button,
-    ContentLayout,
     Alert,
     StatusIndicator,
 } from '@cloudscape-design/components';
@@ -42,6 +41,7 @@ import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
 import DetailsContainer from '../../../../modules/details-container';
 import { LogsComponent } from '../../../../shared/util/log-utils';
 import { useBackgroundRefresh } from '../../../../shared/util/hooks';
+import ContentLayout from '../../../../shared/layout/content-layout';
 
 function TransformDetail () {
     const { projectName, name } = useParams();

--- a/frontend/src/entities/model/create/model-create.tsx
+++ b/frontend/src/entities/model/create/model-create.tsx
@@ -21,7 +21,6 @@ import Form from '@cloudscape-design/components/form';
 import {
     Button,
     Container,
-    ContentLayout,
     FormField,
     Header,
     Input,
@@ -46,6 +45,7 @@ import { AttributeEditorSchema } from '../../../modules/environment-variables/en
 import { NetworkSettings } from '../../jobs/hpo/create/training-definitions/network-settings';
 import { generateNameConstraintText } from '../../../shared/util/form-utils';
 import '../../../shared/validation/helpers/uri';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 export function ModelCreate () {
     const dispatch = useAppDispatch();

--- a/frontend/src/entities/model/detail/model-detail.tsx
+++ b/frontend/src/entities/model/detail/model-detail.tsx
@@ -17,7 +17,6 @@
 import React, { ReactNode, useEffect } from 'react';
 import {
     Container,
-    ContentLayout,
     Header,
     SpaceBetween,
     StatusIndicator,
@@ -33,6 +32,7 @@ import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { formatDate } from '../../../shared/util/date-utils';
 import { formatDisplayBoolean } from '../../../shared/util/form-utils';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function ModelDetail () {
     const { projectName, modelName } = useParams();

--- a/frontend/src/entities/notebook/create/notebook-create.tsx
+++ b/frontend/src/entities/notebook/create/notebook-create.tsx
@@ -18,7 +18,6 @@ import React, { useEffect, useState } from 'react';
 import {
     Button,
     Container,
-    ContentLayout,
     ExpandableSection,
     Form,
     FormField,
@@ -67,6 +66,7 @@ import { InstanceTypeSelector } from '../../../shared/metadata/instance-type-dro
 import { convertDailyStopTime, timezoneDisplayString } from '../../../shared/util/date-utils';
 import { EMRResourceMetadata } from '../../../shared/model/resource-metadata.model';
 import { ServiceTypes } from '../../../shared/model/app.configuration.model';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 export type NotebookCreateProps = {
     update?: boolean;

--- a/frontend/src/entities/notebook/detail/notebook-detail.tsx
+++ b/frontend/src/entities/notebook/detail/notebook-detail.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { ReactNode, useEffect, useState } from 'react';
-import { SpaceBetween, Header, Button, ContentLayout } from '@cloudscape-design/components';
+import { SpaceBetween, Header, Button } from '@cloudscape-design/components';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../../config/store';
 import { INotebook } from '../../../shared/model/notebook.model';
@@ -45,6 +45,7 @@ import { selectCurrentUser } from '../../user/user.reducer';
 import { hasPermission, isAdminOrProjectOwner } from '../../../shared/util/permission-utils';
 import { deletionDescription } from '../../../shared/util/form-utils';
 import { useBackgroundRefresh } from '../../../shared/util/hooks';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function NotebookDetail () {
     const { projectName, name } = useParams();

--- a/frontend/src/entities/project/create/project-create.tsx
+++ b/frontend/src/entities/project/create/project-create.tsx
@@ -23,7 +23,6 @@ import {
     Header,
     FormField,
     Input,
-    ContentLayout,
     Container,
     Textarea,
     Toggle,
@@ -48,6 +47,7 @@ import {
 } from '../../../shared/util/date-utils';
 import { selectCurrentUser } from '../../user/user.reducer';
 import { Timezone } from '../../../shared/model/user.model';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 export type ResourceCreateProperties = {
     isEdit?: boolean;

--- a/frontend/src/entities/project/detail/project-detail.tsx
+++ b/frontend/src/entities/project/detail/project-detail.tsx
@@ -15,7 +15,7 @@
 */
 
 import React, { ReactNode, useEffect, useState } from 'react';
-import { ContentLayout, SpaceBetween, Header, Container, ColumnLayout, StatusIndicator, Grid, Box, Link, Icon, Button} from '@cloudscape-design/components';
+import { SpaceBetween, Header, Container, ColumnLayout, StatusIndicator, Grid, Box, Link, Icon, Button} from '@cloudscape-design/components';
 import { IProject } from '../../../shared/model/project.model';
 import { ResourceType } from '../../../shared/model/resource-metadata.model';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
@@ -41,6 +41,7 @@ import _ from 'lodash';
 import { useBackgroundRefresh } from '../../../shared/util/hooks';
 import { IAppConfiguration } from '../../../shared/model/app.configuration.model';
 import { appConfig } from '../../configuration/configuration-reducer';
+import ContentLayout from '../../../shared/layout/content-layout';
 
 function ProjectDetail () {
     const { projectName } = useParams();

--- a/frontend/src/entities/report/report.tsx
+++ b/frontend/src/entities/report/report.tsx
@@ -18,7 +18,6 @@ import {
     Button,
     ButtonDropdown,
     Container,
-    ContentLayout,
     Form,
     FormField,
     Header,
@@ -46,6 +45,7 @@ import User from '../user/user';
 import { ReportActionHandler } from './report.actions';
 import { reportColumns, resourceTypeOptions, scopeOptions, visibleReportColumns } from './report.columns';
 import { ReportScope, createReport, downloadReport, listReports } from './report.service';
+import ContentLayout from '../../shared/layout/content-layout';
 
 export function Report () {
     const dispatch = useAppDispatch();

--- a/frontend/src/entities/translate-realtime/translate-realtime.tsx
+++ b/frontend/src/entities/translate-realtime/translate-realtime.tsx
@@ -18,11 +18,12 @@ import { useAppDispatch } from '../../config/store';
 import { setBreadcrumbs } from '../../shared/layout/navigation/navigation.reducer';
 import { useParams } from 'react-router-dom';
 import { getBase } from '../../shared/util/breadcrumb-utils';
-import { Container, ContentLayout, Header, Tabs } from '@cloudscape-design/components';
+import { Container, Header, Tabs } from '@cloudscape-design/components';
 import Form from '@cloudscape-design/components/form';
 import { DocTitle, scrollToPageHeader } from '../../shared/doc';
 import { TranslateRealtimeText } from './translate-realtime.text';
 import { TranslateRealtimeDocument } from './translate-realtime.document';
+import ContentLayout from '../../shared/layout/content-layout';
 
 export const TranslateRealtime = () => {
     DocTitle('Real-time translation');

--- a/frontend/src/shared/layout/content-layout.tsx
+++ b/frontend/src/shared/layout/content-layout.tsx
@@ -1,0 +1,29 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ContentLayout as CloudscapeContentLayout, ContentLayoutProps } from '@cloudscape-design/components';
+import React from 'react';
+
+
+export const ContentLayout = (props: ContentLayoutProps) => {
+    
+
+    return (
+        <CloudscapeContentLayout headerVariant='high-contrast' {...props}/>
+    );
+};
+
+export default ContentLayout;

--- a/frontend/src/shared/layout/home/home.tsx
+++ b/frontend/src/shared/layout/home/home.tsx
@@ -23,8 +23,9 @@ import {
 } from '../navigation/navigation.reducer';
 import ProjectCards from '../../../entities/project/card';
 import { selectProject } from '../../../entities/project/card/project-card.reducer';
-import { ContentLayout, Header } from '@cloudscape-design/components';
+import { Header } from '@cloudscape-design/components';
 import { resetCurrentProject } from '../../../entities/project/project.reducer';
+import ContentLayout from '../content-layout';
 
 export const Home = () => {
     const dispatch = useAppDispatch();

--- a/frontend/src/shared/layout/horizontal-line.tsx
+++ b/frontend/src/shared/layout/horizontal-line.tsx
@@ -1,0 +1,32 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ColumnLayout } from '@cloudscape-design/components';
+import React from 'react';
+
+
+export const HorizontalLine = () => {
+    
+
+    return (
+        <ColumnLayout borders='horizontal' columns={1}>
+            <div></div>
+            <div></div>
+        </ColumnLayout>
+    );
+};
+
+export default HorizontalLine;

--- a/frontend/src/shared/layout/navigation/side-navigation.tsx
+++ b/frontend/src/shared/layout/navigation/side-navigation.tsx
@@ -31,6 +31,7 @@ import { colorTextBodyDefault } from '@cloudscape-design/design-tokens';
 import Logo from '../logo/logo';
 import { appConfig } from '../../../entities/configuration/configuration-reducer';
 import { IAppConfiguration } from '../../model/app.configuration.model';
+import HorizontalLine from '../horizontal-line';
 
 export default function SideNavigation () {
     const items: SideNavigationProps.Item[] = useAppSelector((state) => state.navigation.navItems);
@@ -143,8 +144,9 @@ export default function SideNavigation () {
                         </span>
                     </a>
                 </Header>
+                <HorizontalLine/>
             </div>
-            <hr style={{ opacity: 0.2 }} />
+            
             <div style={{ paddingLeft: '28px', paddingRight: '26px', paddingTop: '12px' }}>
                 <FormField label='Current Project'>
                     <Select


### PR DESCRIPTION
*Issue #, if available:* N/A

Cloudscape made changes to change the default look of ContentLayouts: https://github.com/cloudscape-design/components/releases/tag/3.0.639

This PR adds the required settings to revert back to our original look. 

*Description of changes:*
- Create custom ContentLayout that sets high-contrast header
- Create horizontal line component to fix side navigation horizontal line

<img width="1784" alt="Screenshot 2024-06-12 at 2 36 38 PM" src="https://github.com/awslabs/mlspace/assets/28429388/cfbc667c-dfe9-443a-8c90-4548b5342f6b">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
