### PR TITLE
adding warning to save confirmation if user is disabling a service

### DIFF
--- a/frontend/src/entities/configuration/activated-services-configuration.tsx
+++ b/frontend/src/entities/configuration/activated-services-configuration.tsx
@@ -52,9 +52,9 @@ export function ActivatedServicesConfiguration (props: ActivatedServicesConfigur
                     <Alert statusIconAriaLabel='Info'>Activated Services: Activate or deactivate services
                         within MLSpace. IAM permissions that control access to these services within the
                         MLSpace user interface and Jupyter Notebooks will automatically update. Deactivated
-                        services will no longer appear within the MLSpace user interface. Deactivating
-                        services will terminate all active corresponding jobs and instances associated with
-                        the service.</Alert>
+                        services will no longer appear within the MLSpace user interface or be available for
+                        use within Notebooks. Deactivating services will suspend all active corresponding jobs
+                        and instances associated with the service.</Alert>
                     <Grid gridDefinition={Object.keys(configurableServices).map(() => ({colspan: 3}))}>
                         {Object.keys(configurableServices).map((service) => {
                             return (

--- a/frontend/src/entities/configuration/activated-services-configuration.tsx
+++ b/frontend/src/entities/configuration/activated-services-configuration.tsx
@@ -47,12 +47,14 @@ export function ActivatedServicesConfiguration (props: ActivatedServicesConfigur
                 </Header>
             }>
             <SpaceBetween direction='vertical' size='m'>
-                <Alert statusIconAriaLabel='Info'>Activated Services: Activate or deactivate services
-                        within MLSpace. IAM permissions that control access to these services within the
-                        MLSpace user interface and Jupyter Notebooks will automatically update. Deactivated
-                        services will no longer appear within the MLSpace user interface. Deactivating
-                        services will terminate all active corresponding jobs and instances associated with
-                        the service.</Alert>
+                <Alert statusIconAriaLabel='Info'>
+                    Activated Services: Activate or deactivate services within MLSpace. IAM permissions
+                    that control access to these services within the MLSpace user interface and Jupyter
+                    Notebooks will automatically update. Deactivated services will no longer appear within
+                    the MLSpace user interface or be available for use within Notebooks. Deactivating
+                    services will suspend all active corresponding jobs and instances associated with the
+                    service.
+                </Alert>
                 <Grid gridDefinition={Object.keys(configurableServices).map(() => ({colspan: 3}))}>
                     {Object.keys(configurableServices).map((service) => {
                         return (

--- a/frontend/src/entities/configuration/confirm-configuration-changes-modal.tsx
+++ b/frontend/src/entities/configuration/confirm-configuration-changes-modal.tsx
@@ -139,9 +139,10 @@ export function ConfirmConfigurationChangesModal (props: ConfirmConfigurationCha
         >
             <SpaceBetween size={'s'}>
                 <Alert statusIconAriaLabel='Warning' visible={isDeactivatingService} type='warning'>
-                    You are about to deactivate a service: Deactivated services will no longer appear
-                    within the MLSpace user interface. Deactivating services will terminate all active
-                    corresponding jobs and instances associated with the service.
+                    You are about to deactivate a service. Deactivated services will no longer appear
+                    within the MLSpace user interface or be available for use within Notebooks.
+                    Deactivating services will suspend all active corresponding jobs and instances
+                    associated with the service.
                 </Alert>
                 <Container>
                     <TextContent>

--- a/frontend/src/entities/configuration/confirm-configuration-changes-modal.tsx
+++ b/frontend/src/entities/configuration/confirm-configuration-changes-modal.tsx
@@ -23,7 +23,8 @@ import {
     TextContent,
     FormField,
     Input,
-    Modal
+    Modal,
+    Alert
 } from '@cloudscape-design/components';
 import React, {useEffect, useMemo, useState} from 'react';
 import _ from 'lodash';
@@ -100,6 +101,10 @@ export function ConfirmConfigurationChangesModal (props: ConfirmConfigurationCha
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.appConfiguration, props.inMemoryConfiguration]);
 
+    const isDeactivatingService = !_.isEmpty(changesDiff) &&
+        Object.keys(changesDiff).includes('EnabledServices') &&
+        Object.values(changesDiff['EnabledServices']).includes(false);
+
     useEffect(() => {
         props.setFields({ 'changeReason': changeReason });
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -133,6 +138,11 @@ export function ConfirmConfigurationChangesModal (props: ConfirmConfigurationCha
             }
         >
             <SpaceBetween size={'s'}>
+                <Alert statusIconAriaLabel='Warning' visible={isDeactivatingService} type='warning'>
+                    You are about to deactivate a service: Deactivated services will no longer appear
+                    within the MLSpace user interface. Deactivating services will terminate all active
+                    corresponding jobs and instances associated with the service.
+                </Alert>
                 <Container>
                     <TextContent>
                         {_.isEmpty(changesDiff) ? <p>No changes detected</p> : jsonToOutline(changesDiff)}


### PR DESCRIPTION
Adding a warning to the save confirmation modal if a user is disabling a service letting them know what will happen.

<img width="602" alt="Screenshot 2024-06-13 at 11 04 36 AM" src="https://github.com/awslabs/mlspace/assets/14100972/80f1c7a5-8930-4ece-a4b5-d814542024d3">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
