### PR TITLE
Revert role name so CDK deploy doesn't fail

### DIFF
--- a/frontend/docs/admin-guide/install.md
+++ b/frontend/docs/admin-guide/install.md
@@ -87,7 +87,7 @@ or make any additional changes required for your environment.
 |`{EMR_DEFAULT_ROLE_ARN}` | The ARN of the role that will be used as the "ServiceRole" for all EMR Clusters created via {{ $params.APPLICATION_NAME }} | `arn:aws:iam::123456789012:role/EMR_DefaultRole`|
 |`{EMR_EC2_INSTANCE_ROLE_ARN}` | The ARN of the role that will be used as the "JobFlowRole" and "AutoScalingRole" for all EMR Clusters created via {{ $params.APPLICATION_NAME }} | `arn:aws:iam::123456789012:role/EMR_EC2_DefaultRole`|
 | `{MLSPACE_APP_ROLE_NAME}` | The name of the {{ $params.APPLICATION_NAME }} application role | `mlspace-app-role` |
-| `{MLSPACE_SYSTEM_ROLE_NAME}` | The name of the {{ $params.APPLICATION_NAME }} system role | `mlspace-system-role` |
+| `{MLSPACE_SYSTEM_ROLE_NAME}` | The name of the {{ $params.APPLICATION_NAME }} system role | `mlspaceSystemRole` |
 
 #### Notebook Role
 

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -87,7 +87,7 @@ export class IAMStack extends Stack {
         );
 
         // Role names
-        const mlspaceSystemRoleName = 'mlspace-system-role';
+        const mlspaceSystemRoleName = 'mlspaceSystemRole';
         const mlSpaceNotebookRoleName = 'mlspace-notebook-role';
 
         const invertedBooleanConditions = (conditions: {[key: string]: string}) => Object.fromEntries(Object.entries(conditions).map(([key, value]) => {
@@ -1002,12 +1002,11 @@ export class IAMStack extends Stack {
          * to terminate EMR clusters even though users can't perform any EMR actions.
          * These actions include cleaning up resources for deleted projects and suspended users.
          */
-        const mlSpaceSystemRoleName = 'mlspace-system-role';
         if (props.mlspaceConfig.SYSTEM_ROLE_ARN) {
             this.mlSpaceSystemRole = Role.fromRoleArn(this, mlspaceSystemRoleName, props.mlspaceConfig.SYSTEM_ROLE_ARN);
         } else {
             const systemPolicy = new ManagedPolicy(this, 'mlspace-system-policy', {
-                statements: appPolicyAndStatements(this.partition, Aws.REGION, mlSpaceSystemRoleName),
+                statements: appPolicyAndStatements(this.partition, Aws.REGION, mlspaceSystemRoleName),
             });
             const systemPolicyAllowPrinciples = props.enableTranslate
                 ? new CompositePrincipal(
@@ -1016,7 +1015,7 @@ export class IAMStack extends Stack {
                 )
                 : new ServicePrincipal('lambda.amazonaws.com');
             this.mlSpaceSystemRole = new Role(this, mlspaceSystemRoleName, {
-                roleName: mlSpaceSystemRoleName,
+                roleName: mlspaceSystemRoleName,
                 assumedBy: systemPolicyAllowPrinciples,
                 managedPolicies: [
                     systemPolicy,


### PR DESCRIPTION
*Description of changes:* the system IAM role already exists with this name so I'm going to stick with it. 

Changing it would mean we need to tear down all of our stacks and redeploy to rename it which doesn't seem worth it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
