### PR TITLE
Bugfix/create network interface permission

### DIFF
--- a/frontend/docs/admin-guide/install.md
+++ b/frontend/docs/admin-guide/install.md
@@ -67,12 +67,9 @@ _The cleanup role needs to exist but we do not need the ARN_
 ### Application Roles
 
 We generally expect customers to use their own roles for the {{ $params.APPLICATION_NAME }} APIGW and lambda execution role as well as for the default notebook role.
-While customers may scope these roles down based on the guidelines of their own organization, the following can be used to quickly stand up
-an instance of {{ $params.APPLICATION_NAME }} for demo purposes only. As written these roles and policies should not be used for production usecases.
+While customers may scope these roles down based on the guidelines of their own organization, the following can be used to quickly stand up an instance of {{ $params.APPLICATION_NAME }} for demo purposes only. As written these roles and policies should not be used for production usecases.
 
-The policies below include a number of placeholder variables that you'll need to replace. These policies are meant to serve as a starting point and are tightly scoped
-to the resources {{ $params.APPLICATION_NAME }} expects to use, you can relax these restrictions as necessary
-or make any additional changes required for your environment.
+The policies below include a number of placeholder variables that you'll need to replace. These policies are meant to serve as a starting point and are tightly scoped to the resources {{ $params.APPLICATION_NAME }} expects to use, you can relax these restrictions as necessary or make any additional changes required for your environment.
 
 | Variable | Expected Value | Example |
 |--|--|--|
@@ -1407,6 +1404,8 @@ policy. From the IAM Service page click "Policies" on the left hand side. **Note
         },
         {
             "Action": [
+                "ec2:CreateNetworkInterface",
+                "ec2:CreateNetworkInterfacePermission",
                 "ec2:DeleteNetworkInterface",
                 "ec2:DeleteNetworkInterfacePermission"
             ],

--- a/lib/stacks/vpc.ts
+++ b/lib/stacks/vpc.ts
@@ -94,7 +94,7 @@ export class VPCStack extends Stack {
 
             if (props.deployCWEndpoint && !props.isIso) {
                 this.vpc.addInterfaceEndpoint('mlspace-cw-interface-endpoint', {
-                    service: InterfaceVpcEndpointAwsService.CLOUDWATCH,
+                    service: InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING,
                     privateDnsEnabled: true,
                 });
             }


### PR DESCRIPTION
*Description of changes:* While deploying MLS onto a burner account with `MANAGE_IAM_ROLES` set to false, I encountered an error for the system policy not having permission to create a network interface.

This error only seems to occur during deployment as this role is used to deploy the lambda into the VPC, which requires the CreateNetworkInterface permission.

I also noticed in the VPC stack that InterfaceVpcEndpointAwsService.CLOUDWATCH has been marked as deprecated and it recommends to use InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
