### PR TITLE
Deny services policy retroactive attachment

### DIFF
--- a/backend/src/ml_space_lambda/app_configuration/policy_helper/active_service_policy_manager.py
+++ b/backend/src/ml_space_lambda/app_configuration/policy_helper/active_service_policy_manager.py
@@ -189,6 +189,7 @@ class ActiveServicePolicyManager:
             "deny",
             on_create_attach_to_notebook_role=True,
             on_create_attach_to_app_role=True,
+            on_create_attach_to_existing_dynamic_roles=True,
         )
 
         return resource_types_to_suspend

--- a/backend/src/ml_space_lambda/utils/iam_manager.py
+++ b/backend/src/ml_space_lambda/utils/iam_manager.py
@@ -474,6 +474,7 @@ class IAMManager:
         policy_type_identifier: str,
         on_create_attach_to_notebook_role: bool = False,
         on_create_attach_to_app_role: bool = False,
+        on_create_attach_to_existing_dynamic_roles: bool = False,
         expected_policy_version: int = None,
     ):
         aws_account = self.sts_client.get_caller_identity()["Account"]
@@ -500,8 +501,9 @@ class IAMManager:
             if on_create_attach_to_app_role:
                 self.iam_client.attach_role_policy(RoleName=self.app_role_name, PolicyArn=policy_arn)
 
-            dynamic_role_names = self.find_dynamic_user_roles()
-            self.attach_policies_to_roles([policy_arn], dynamic_role_names)
+            if on_create_attach_to_existing_dynamic_roles:
+                role_names = self.find_dynamic_user_roles()
+                self.attach_policies_to_roles([policy_arn], role_names)
 
         # If the policy does exist, then update it
         elif expected_policy_version is None or existing_policy_version < expected_policy_version:

--- a/backend/test/app_configuration/test_update_configuration.py
+++ b/backend/test/app_configuration/test_update_configuration.py
@@ -309,6 +309,7 @@ def test_update_active_services_all_active_success(
         "deny",
         on_create_attach_to_notebook_role=True,
         on_create_attach_to_app_role=True,
+        on_create_attach_to_existing_dynamic_roles=True,
     )
 
 
@@ -368,6 +369,7 @@ def test_update_active_services_single_deny_success(
         "deny",
         on_create_attach_to_notebook_role=True,
         on_create_attach_to_app_role=True,
+        on_create_attach_to_existing_dynamic_roles=True,
     )
     if "resource_type" in type_info:
         mock_suspend_all_of_type.assert_called_with(type_info["resource_type"])
@@ -423,5 +425,6 @@ def test_update_active_services_group_deny_success(
         "deny",
         on_create_attach_to_notebook_role=True,
         on_create_attach_to_app_role=True,
+        on_create_attach_to_existing_dynamic_roles=True,
     )
     mock_suspend_all_of_type.assert_called_with(ResourceType.BATCH_TRANSLATE_JOB)

--- a/backend/test/utils/test_iam_manager.py
+++ b/backend/test/utils/test_iam_manager.py
@@ -460,6 +460,7 @@ class TestIAMSupport(TestCase):
             "test-type",
             "test-type-1",
             on_create_attach_to_notebook_role=True,
+            on_create_attach_to_existing_dynamic_roles=True,
             expected_policy_version="2",
         )
         attached_policies_response = self.iam_client.list_attached_role_policies(RoleName=NOTEBOOK_ROLE_NAME)


### PR DESCRIPTION
*Description of changes:* Moves dynamic role attachment within a conditional. Should not affect current processing, but prevents unintentional attachment to dynamic roles in the future.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
