### PR TITLE
revert cloudscape version where high-contrast header is default.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@amzn/mlspace",
             "version": "1.5.0",
             "dependencies": {
-                "@cloudscape-design/components": "^3.0.580",
+                "@cloudscape-design/components": "3.0.638",
                 "@cloudscape-design/components-themeable": "^3.0.595",
                 "@cloudscape-design/design-tokens": "^3.0.34",
                 "@cloudscape-design/global-styles": "^1.0.25",
@@ -2362,9 +2362,9 @@
             }
         },
         "node_modules/@cloudscape-design/components": {
-            "version": "3.0.656",
-            "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.656.tgz",
-            "integrity": "sha512-qBkPuSnp0CZfhNkqyFRYaTUieGpAWYWf+fWr6QX4crAxrw/MmzpgOXZo01RhudOiAT493HO1DluWaxh9cH58Hg==",
+            "version": "3.0.638",
+            "resolved": "https://registry.npmjs.org/@cloudscape-design/components/-/components-3.0.638.tgz",
+            "integrity": "sha512-epLgZICyc0003tyFzbcS84gdbzSCv3kfA/YEkD96PuWnqfKoV76ohVcBQbBzC/Ynj1NrZ+FDVM2QvQAhZjJxCg==",
             "dependencies": {
                 "@cloudscape-design/collection-hooks": "^1.0.0",
                 "@cloudscape-design/component-toolkit": "^1.0.0-beta",
@@ -2374,7 +2374,7 @@
                 "@dnd-kit/sortable": "^7.0.2",
                 "@dnd-kit/utilities": "^3.2.1",
                 "@juggle/resize-observer": "^3.3.1",
-                "ace-builds": "^1.34.0",
+                "ace-builds": "^1.32.6",
                 "balanced-match": "^1.0.2",
                 "clsx": "^1.1.0",
                 "d3-shape": "^1.3.7",
@@ -2392,9 +2392,9 @@
             }
         },
         "node_modules/@cloudscape-design/components-themeable": {
-            "version": "3.0.671",
-            "resolved": "https://registry.npmjs.org/@cloudscape-design/components-themeable/-/components-themeable-3.0.671.tgz",
-            "integrity": "sha512-k+AXUFP2eWc3KwTGoRVvlxC65oBE+r4uKlmCORBuFkBl6opWmZGwkncjy1thtJsdqgh2b4jb9QAr6gi6ci8g4g==",
+            "version": "3.0.677",
+            "resolved": "https://registry.npmjs.org/@cloudscape-design/components-themeable/-/components-themeable-3.0.677.tgz",
+            "integrity": "sha512-CTllcNmsrJzPKZ6cSFgNqfw40VVsPC6lXV3fVfiJmwW/dFe3Ai9Z7h+zW/EpYuKWZg+5x5+8+F24Ou2/3DpL5g==",
             "dependencies": {
                 "@cloudscape-design/theming-build": "^1.0.0"
             }
@@ -2419,9 +2419,9 @@
             }
         },
         "node_modules/@cloudscape-design/theming-build": {
-            "version": "1.0.56",
-            "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.56.tgz",
-            "integrity": "sha512-Wu8nt8c494Ntr/yDHuJco1BMEMGa93I9Poy2OVYs8sf5z9YCUTSsNtpvERwzRSZni5Co2inwLj/TKIxtYxw1Ow==",
+            "version": "1.0.57",
+            "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-build/-/theming-build-1.0.57.tgz",
+            "integrity": "sha512-vGrR0THmkJsn0pd3EeOi5uO2Zn/yZJbUl4VNdozBcdjq5WaoMm06Ocr/eeWAjlP7IubZokzY/+aLY/iUjK+W8w==",
             "dependencies": {
                 "autoprefixer": "^10.4.8",
                 "glob": "^7.2.3",
@@ -2438,9 +2438,9 @@
             }
         },
         "node_modules/@cloudscape-design/theming-runtime": {
-            "version": "1.0.49",
-            "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.49.tgz",
-            "integrity": "sha512-rQPZGOhpGsfrrHali6nbCzSzXKhbC3mlFG+WHuDYKZwoZWU2D+4/sOU7oTNrShdnLzm8DfRRVqZsY1WzHCb/SA==",
+            "version": "1.0.50",
+            "resolved": "https://registry.npmjs.org/@cloudscape-design/theming-runtime/-/theming-runtime-1.0.50.tgz",
+            "integrity": "sha512-MTT8YaLiMqEmaKJMbjly2PVfLee3rBEsAwjJ8JDaOeA+DeSlp25KUE1I41YnRim7Ds0Jz7+hODYJ88KZUyknCw==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -2829,9 +2829,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -2845,9 +2845,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
             "cpu": [
                 "arm"
             ],
@@ -2861,9 +2861,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
             "cpu": [
                 "arm64"
             ],
@@ -2877,9 +2877,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
             "cpu": [
                 "x64"
             ],
@@ -2893,9 +2893,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2909,9 +2909,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
             "cpu": [
                 "x64"
             ],
@@ -2925,9 +2925,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
             "cpu": [
                 "arm64"
             ],
@@ -2941,9 +2941,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
             "cpu": [
                 "x64"
             ],
@@ -2957,9 +2957,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
             "cpu": [
                 "arm"
             ],
@@ -2973,9 +2973,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2989,9 +2989,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
             "cpu": [
                 "ia32"
             ],
@@ -3005,9 +3005,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
             "cpu": [
                 "loong64"
             ],
@@ -3021,9 +3021,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
             "cpu": [
                 "mips64el"
             ],
@@ -3037,9 +3037,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
             "cpu": [
                 "ppc64"
             ],
@@ -3053,9 +3053,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
             "cpu": [
                 "riscv64"
             ],
@@ -3069,9 +3069,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
             "cpu": [
                 "s390x"
             ],
@@ -3085,9 +3085,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
             "cpu": [
                 "x64"
             ],
@@ -3101,9 +3101,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
             "cpu": [
                 "x64"
             ],
@@ -3117,9 +3117,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
             "cpu": [
                 "x64"
             ],
@@ -3133,9 +3133,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
             "cpu": [
                 "x64"
             ],
@@ -3149,9 +3149,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
             "cpu": [
                 "arm64"
             ],
@@ -3165,9 +3165,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
             "cpu": [
                 "ia32"
             ],
@@ -3181,9 +3181,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
             "cpu": [
                 "x64"
             ],
@@ -4755,18 +4755,18 @@
             "dev": true
         },
         "node_modules/@shikijs/core": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.6.4.tgz",
-            "integrity": "sha512-WTU9rzZae1p2v6LOxMf6LhtmZOkIHYYW160IuahUyJy7YXPPjyWZLR1ag+SgD22ZMxZtz1gfU6Tccc8t0Il/XA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.7.0.tgz",
+            "integrity": "sha512-O6j27b7dGmJbR3mjwh/aHH8Ld+GQvA0OQsNO43wKWnqbAae3AYXrhFyScHGX8hXZD6vX2ngjzDFkZY5srtIJbQ==",
             "dev": true
         },
         "node_modules/@shikijs/transformers": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.6.4.tgz",
-            "integrity": "sha512-NqDt7gUg3ayVBnsipT/KoL1pqsVbsvT/2cB0pb5SG2q72qjAv9Lb5OP99pL//BMmI+sMTo+TeARntklyBu4mZQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.7.0.tgz",
+            "integrity": "sha512-QX3TP+CS4yYLt4X4Dk7wT0MsC7yweTYHMAAKY+ay+uuR9yRdFae/h+hivny2O+YixJHfZl57xtiZfWSrHdyVhQ==",
             "dev": true,
             "dependencies": {
-                "shiki": "1.6.4"
+                "shiki": "1.7.0"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -7080,39 +7080,39 @@
             "dev": true
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-            "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.29.tgz",
+            "integrity": "sha512-TFKiRkKKsRCKvg/jTSSKK7mYLJEQdUiUfykbG49rubC9SfDyvT2JrzTReopWlz2MxqeLyxh9UZhvxEIBgAhtrg==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.24.4",
-                "@vue/shared": "3.4.27",
+                "@babel/parser": "^7.24.7",
+                "@vue/shared": "3.4.29",
                 "entities": "^4.5.0",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.0"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-            "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.29.tgz",
+            "integrity": "sha512-A6+iZ2fKIEGnfPJejdB7b1FlJzgiD+Y/sxxKwJWg1EbJu6ZPgzaPQQ51ESGNv0CP6jm6Z7/pO6Ia8Ze6IKrX7w==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-core": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-core": "3.4.29",
+                "@vue/shared": "3.4.29"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
-            "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.29.tgz",
+            "integrity": "sha512-zygDcEtn8ZimDlrEQyLUovoWgKQic6aEQqRXce2WXBvSeHbEbcAsXyCk9oG33ZkyWH4sl9D3tkYc1idoOkdqZQ==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.24.4",
-                "@vue/compiler-core": "3.4.27",
-                "@vue/compiler-dom": "3.4.27",
-                "@vue/compiler-ssr": "3.4.27",
-                "@vue/shared": "3.4.27",
+                "@babel/parser": "^7.24.7",
+                "@vue/compiler-core": "3.4.29",
+                "@vue/compiler-dom": "3.4.29",
+                "@vue/compiler-ssr": "3.4.29",
+                "@vue/shared": "3.4.29",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.10",
                 "postcss": "^8.4.38",
@@ -7120,107 +7120,110 @@
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
-            "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.29.tgz",
+            "integrity": "sha512-rFbwCmxJ16tDp3N8XCx5xSQzjhidYjXllvEcqX/lopkoznlNPz3jyy0WGJCyhAaVQK677WWFt3YO/WUEkMMUFQ==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-dom": "3.4.29",
+                "@vue/shared": "3.4.29"
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.2.1.tgz",
-            "integrity": "sha512-6oNCtyFOrNdqm6GUkFujsCgFlpbsHLnZqq7edeM/+cxAbMyCWvsaCsIMUaz7AiluKLccCGEM8fhOsjaKgBvb7g==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.3.0.tgz",
+            "integrity": "sha512-EQ6DIm9AuL9q6IzjjnxeHWgzHzZTI+0ZGyLyG6faLN1e0tzLWPut58OtvFbLP/hbEhE5zPlsdUsH1uFr7RVFYw==",
             "dev": true,
             "dependencies": {
-                "@vue/devtools-kit": "^7.2.1"
+                "@vue/devtools-kit": "^7.3.0"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.2.1.tgz",
-            "integrity": "sha512-Wak/fin1X0Q8LLIfCAHBrdaaB+R6IdpSXsDByPHbQ3BmkCP0/cIo/oEGp9i0U2+gEqD4L3V9RDjNf1S34DTzQQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.3.0.tgz",
+            "integrity": "sha512-J9C+ue3Ka8cumQY/hMsNTcbb1tczqVBBXFMw4isa5YvPjyIBgEtJBfDSUVIK3nE+YWk7UNliUuCcE1GHEKaGcw==",
             "dev": true,
             "dependencies": {
-                "@vue/devtools-shared": "^7.2.1",
+                "@vue/devtools-shared": "^7.3.0",
+                "birpc": "^0.2.17",
                 "hookable": "^5.5.3",
                 "mitt": "^3.0.1",
                 "perfect-debounce": "^1.0.0",
-                "speakingurl": "^14.0.1"
+                "speakingurl": "^14.0.1",
+                "superjson": "^2.2.1"
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.2.1.tgz",
-            "integrity": "sha512-PCJF4UknJmOal68+X9XHyVeQ+idv0LFujkTOIW30+GaMJqwFVN9LkQKX4gLqn61KkGMdJTzQ1bt7EJag3TI6AA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.3.0.tgz",
+            "integrity": "sha512-bYw4BtZclxzVrYBeYYHzNOcLlvVZbe9tutwtrixTtdgynHvuSJa5KI2MqWiumpGYm2feFI5sHlC8Vt61v4z18g==",
             "dev": true,
             "dependencies": {
                 "rfdc": "^1.3.1"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
-            "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.29.tgz",
+            "integrity": "sha512-w8+KV+mb1a8ornnGQitnMdLfE0kXmteaxLdccm2XwdFxXst4q/Z7SEboCV5SqJNpZbKFeaRBBJBhW24aJyGINg==",
             "dev": true,
             "dependencies": {
-                "@vue/shared": "3.4.27"
+                "@vue/shared": "3.4.29"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
-            "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.29.tgz",
+            "integrity": "sha512-s8fmX3YVR/Rk5ig0ic0NuzTNjK2M7iLuVSZyMmCzN/+Mjuqqif1JasCtEtmtoJWF32pAtUjyuT2ljNKNLeOmnQ==",
             "dev": true,
             "dependencies": {
-                "@vue/reactivity": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/reactivity": "3.4.29",
+                "@vue/shared": "3.4.29"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
-            "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.29.tgz",
+            "integrity": "sha512-gI10atCrtOLf/2MPPMM+dpz3NGulo9ZZR9d1dWo4fYvm+xkfvRrw1ZmJ7mkWtiJVXSsdmPbcK1p5dZzOCKDN0g==",
             "dev": true,
             "dependencies": {
-                "@vue/runtime-core": "3.4.27",
-                "@vue/shared": "3.4.27",
+                "@vue/reactivity": "3.4.29",
+                "@vue/runtime-core": "3.4.29",
+                "@vue/shared": "3.4.29",
                 "csstype": "^3.1.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
-            "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.29.tgz",
+            "integrity": "sha512-HMLCmPI2j/k8PVkSBysrA2RxcxC5DgBiCdj7n7H2QtR8bQQPqKAe8qoaxLcInzouBmzwJ+J0x20ygN/B5mYBng==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-ssr": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-ssr": "3.4.29",
+                "@vue/shared": "3.4.29"
             },
             "peerDependencies": {
-                "vue": "3.4.27"
+                "vue": "3.4.29"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-            "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.29.tgz",
+            "integrity": "sha512-hQ2gAQcBO/CDpC82DCrinJNgOHI2v+FA7BDW4lMSPeBpQ7sRe2OLHWe5cph1s7D8DUQAwRt18dBDfJJ220APEA==",
             "dev": true
         },
         "node_modules/@vueuse/core": {
-            "version": "10.10.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.10.1.tgz",
-            "integrity": "sha512-8Vr8wxILdK+qfBjbngav8LVI+6UuM2TQCufRKMPz/GrpLHQ6dbY6kL5PLa9Eobq8JRrMaDyArPX9Jj18fMTPew==",
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.0.tgz",
+            "integrity": "sha512-x3sD4Mkm7PJ+pcq3HX8PLPBadXCAlSDR/waK87dz0gQE+qJnaaFhc/dZVfJz+IUYzTMVGum2QlR7ImiJQN4s6g==",
             "dev": true,
             "dependencies": {
                 "@types/web-bluetooth": "^0.0.20",
-                "@vueuse/metadata": "10.10.1",
-                "@vueuse/shared": "10.10.1",
+                "@vueuse/metadata": "10.11.0",
+                "@vueuse/shared": "10.11.0",
                 "vue-demi": ">=0.14.8"
             },
             "funding": {
@@ -7253,111 +7256,19 @@
                 }
             }
         },
-        "node_modules/@vueuse/integrations": {
-            "version": "10.10.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.10.1.tgz",
-            "integrity": "sha512-b4iPz4NLk2g5u9GNgTpYqNN1pzYWPpIglHTg6eDjJwKB7OfzJP4m5kQlzn2oRH7U0OlEOCVPrdDfqneuS9YNTg==",
-            "dev": true,
-            "dependencies": {
-                "@vueuse/core": "10.10.1",
-                "@vueuse/shared": "10.10.1",
-                "vue-demi": ">=0.14.8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "async-validator": "*",
-                "axios": "*",
-                "change-case": "*",
-                "drauu": "*",
-                "focus-trap": "*",
-                "fuse.js": "*",
-                "idb-keyval": "*",
-                "jwt-decode": "*",
-                "nprogress": "*",
-                "qrcode": "*",
-                "sortablejs": "*",
-                "universal-cookie": "*"
-            },
-            "peerDependenciesMeta": {
-                "async-validator": {
-                    "optional": true
-                },
-                "axios": {
-                    "optional": true
-                },
-                "change-case": {
-                    "optional": true
-                },
-                "drauu": {
-                    "optional": true
-                },
-                "focus-trap": {
-                    "optional": true
-                },
-                "fuse.js": {
-                    "optional": true
-                },
-                "idb-keyval": {
-                    "optional": true
-                },
-                "jwt-decode": {
-                    "optional": true
-                },
-                "nprogress": {
-                    "optional": true
-                },
-                "qrcode": {
-                    "optional": true
-                },
-                "sortablejs": {
-                    "optional": true
-                },
-                "universal-cookie": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-            "version": "0.14.8",
-            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
-            "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
-            "dev": true,
-            "hasInstallScript": true,
-            "bin": {
-                "vue-demi-fix": "bin/vue-demi-fix.js",
-                "vue-demi-switch": "bin/vue-demi-switch.js"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@vue/composition-api": "^1.0.0-rc.1",
-                "vue": "^3.0.0-0 || ^2.6.0"
-            },
-            "peerDependenciesMeta": {
-                "@vue/composition-api": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@vueuse/metadata": {
-            "version": "10.10.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.10.1.tgz",
-            "integrity": "sha512-dpEL5afVLUqbchwGiLrV6spkl4/6UOKJ3YgxFE+wWLj/LakyIZUC83bfeFgbHkRcNhsAqTQCGR74jImsLfK8pg==",
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.0.tgz",
+            "integrity": "sha512-kQX7l6l8dVWNqlqyN3ePW3KmjCQO3ZMgXuBMddIu83CmucrsBfXlH+JoviYyRBws/yLTQO8g3Pbw+bdIoVm4oQ==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@vueuse/shared": {
-            "version": "10.10.1",
-            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.10.1.tgz",
-            "integrity": "sha512-edqexI+RQpoeqDxTatqBZa+K87ganbrwpoP++Fd9828U3js5jzwcEDeyrYcUgkKZ5LLL8q7M5SOMvSpMrxBPxg==",
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
+            "integrity": "sha512-fyNoIXEq3PfX1L3NkNhtVQUSRtqYwJtJg+Bp9rIzculIZWHTkKSysujrOk2J+NrRulLTQH9+3gGSfYLWSEWU1A==",
             "dev": true,
             "dependencies": {
                 "vue-demi": ">=0.14.8"
@@ -7576,9 +7487,9 @@
             "integrity": "sha512-bwDKqjqNccC/MSujqnYTeAS5dIR8UmGLP0R90mvsJY0FRC8NUWBSTfj34+EIzo2NWc/gV8IZTqv4fXaiZJpCtA=="
         },
         "node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+            "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -8138,9 +8049,9 @@
             }
         },
         "node_modules/aws-cdk-lib": {
-            "version": "2.145.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.145.0.tgz",
-            "integrity": "sha512-0RCKdojCtF74rI2gGi9KUFVUKykTIMEs3ANjruIjxEz6d2cAsy9c2k+nCCSMdqhKZ9aPJgmBFewiw03Z8NtPig==",
+            "version": "2.146.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.146.0.tgz",
+            "integrity": "sha512-W3F2zH+P7hUxmu2dlEKJBBi6Twc4//NsJJW00h2LN0dKU+2302QY8jR+P7jgEYzZ7U50phtH4zO6BPmJrhLVEg==",
             "bundleDependencies": [
                 "@balena/dockerignore",
                 "case",
@@ -8167,7 +8078,7 @@
                 "mime-types": "^2.1.35",
                 "minimatch": "^3.1.2",
                 "punycode": "^2.3.1",
-                "semver": "^7.6.0",
+                "semver": "^7.6.2",
                 "table": "^6.8.2",
                 "yaml": "1.10.2"
             },
@@ -8185,7 +8096,7 @@
             "license": "Apache-2.0"
         },
         "node_modules/aws-cdk-lib/node_modules/ajv": {
-            "version": "8.13.0",
+            "version": "8.16.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8365,18 +8276,6 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/aws-cdk-lib/node_modules/mime-db": {
             "version": "1.52.0",
             "dev": true,
@@ -8429,13 +8328,10 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/semver": {
-            "version": "7.6.0",
+            "version": "7.6.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -8519,12 +8415,6 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
-        },
-        "node_modules/aws-cdk-lib/node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
         },
         "node_modules/aws-cdk-lib/node_modules/yaml": {
             "version": "1.10.2",
@@ -8959,6 +8849,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/birpc": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.17.tgz",
+            "integrity": "sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
         "node_modules/bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -9198,9 +9097,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001632",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-            "integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+            "version": "1.0.30001636",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
+            "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9653,6 +9552,21 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "dev": true
+        },
+        "node_modules/copy-anything": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+            "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+            "dev": true,
+            "dependencies": {
+                "is-what": "^4.1.8"
+            },
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
         },
         "node_modules/core-js": {
             "version": "3.37.1",
@@ -10793,9 +10707,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.799",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.799.tgz",
-            "integrity": "sha512-3D3DwWkRTzrdEpntY0hMLYwj7SeBk1138CkPE8sBDSj3WzrzOiG2rHm3luw8jucpf+WiyLBCZyU9lMHyQI9M9Q=="
+            "version": "1.4.803",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.803.tgz",
+            "integrity": "sha512-61H9mLzGOCLLVsnLiRzCbc63uldP0AniRYPV3hbGVtONA1pI7qSGILdbofR7A8TMbOypDocEAjH/e+9k1QIe3g=="
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -11058,9 +10972,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -11070,29 +10984,29 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.20.2",
-                "@esbuild/android-arm": "0.20.2",
-                "@esbuild/android-arm64": "0.20.2",
-                "@esbuild/android-x64": "0.20.2",
-                "@esbuild/darwin-arm64": "0.20.2",
-                "@esbuild/darwin-x64": "0.20.2",
-                "@esbuild/freebsd-arm64": "0.20.2",
-                "@esbuild/freebsd-x64": "0.20.2",
-                "@esbuild/linux-arm": "0.20.2",
-                "@esbuild/linux-arm64": "0.20.2",
-                "@esbuild/linux-ia32": "0.20.2",
-                "@esbuild/linux-loong64": "0.20.2",
-                "@esbuild/linux-mips64el": "0.20.2",
-                "@esbuild/linux-ppc64": "0.20.2",
-                "@esbuild/linux-riscv64": "0.20.2",
-                "@esbuild/linux-s390x": "0.20.2",
-                "@esbuild/linux-x64": "0.20.2",
-                "@esbuild/netbsd-x64": "0.20.2",
-                "@esbuild/openbsd-x64": "0.20.2",
-                "@esbuild/sunos-x64": "0.20.2",
-                "@esbuild/win32-arm64": "0.20.2",
-                "@esbuild/win32-ia32": "0.20.2",
-                "@esbuild/win32-x64": "0.20.2"
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/escalade": {
@@ -12705,9 +12619,9 @@
             }
         },
         "node_modules/foreground-child": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+            "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
             "dev": true,
             "dependencies": {
                 "cross-spawn": "^7.0.0",
@@ -14391,6 +14305,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-what": {
+            "version": "4.1.16",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+            "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.13"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
             }
         },
         "node_modules/is-wsl": {
@@ -17379,9 +17305,9 @@
             }
         },
         "node_modules/jsdom/node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "dev": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -17565,9 +17491,9 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
-            "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.7.0.tgz",
+            "integrity": "sha512-KAc66u6LxWL8MifQ94oG3YGKYWDwz/Gi0T15lN//GaQoZe08vQGFJxrXkPAeu50UXgvJPPaRKVGuP1TRUm/aHQ==",
             "dev": true,
             "dependencies": {
                 "picocolors": "^1.0.0",
@@ -23245,9 +23171,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-            "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true
         },
         "node_modules/rimraf": {
@@ -23437,9 +23363,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.77.5",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.5.tgz",
-            "integrity": "sha512-oDfX1mukIlxacPdQqNb6mV2tVCrnE+P3nVYioy72V5tlk56CPNcO4TCuFcaCRKKfJ1M3lH95CleRS+dVKL2qMg==",
+            "version": "1.77.6",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
+            "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -23811,12 +23737,12 @@
             }
         },
         "node_modules/shiki": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.6.4.tgz",
-            "integrity": "sha512-X88chM7w8jnadoZtjPTi5ahCJx9pc9f8GfEkZAEYUTlcUZIEw2D/RY86HI/LkkE7Nj8TQWkiBfaFTJ3VJT6ESg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.7.0.tgz",
+            "integrity": "sha512-H5pMn4JA7ayx8H0qOz1k2qANq6mZVCMl1gKLK6kWIrv1s2Ial4EmD4s4jE8QB5Dw03d/oCQUxc24sotuyR5byA==",
             "dev": true,
             "dependencies": {
-                "@shikijs/core": "1.6.4"
+                "@shikijs/core": "1.7.0"
             }
         },
         "node_modules/side-channel": {
@@ -24443,6 +24369,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/superjson": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
+            "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+            "dev": true,
+            "dependencies": {
+                "copy-anything": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/supports-color": {
@@ -25425,9 +25363,9 @@
             }
         },
         "node_modules/vitepress/node_modules/@types/node": {
-            "version": "20.14.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-            "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+            "version": "20.14.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.3.tgz",
+            "integrity": "sha512-Nuzqa6WAxeGnve6SXqiPAM9rA++VQs+iLZ1DDd56y0gdvygSZlQvZuvdFPR3yLqkVxPu4WrO02iDEyH1g+wazw==",
             "dev": true,
             "optional": true,
             "peer": true,
@@ -25446,6 +25384,111 @@
             "peerDependencies": {
                 "vite": "^5.0.0",
                 "vue": "^3.2.25"
+            }
+        },
+        "node_modules/vitepress/node_modules/@vueuse/integrations": {
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.11.0.tgz",
+            "integrity": "sha512-Pp6MtWEIr+NDOccWd8j59Kpjy5YDXogXI61Kb1JxvSfVBO8NzFQkmrKmSZz47i+ZqHnIzxaT38L358yDHTncZg==",
+            "dev": true,
+            "dependencies": {
+                "@vueuse/core": "10.11.0",
+                "@vueuse/shared": "10.11.0",
+                "vue-demi": ">=0.14.8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "async-validator": "^4",
+                "axios": "^1",
+                "change-case": "^4",
+                "drauu": "^0.3",
+                "focus-trap": "^7",
+                "fuse.js": "^6",
+                "idb-keyval": "^6",
+                "jwt-decode": "^3",
+                "nprogress": "^0.2",
+                "qrcode": "^1.5",
+                "sortablejs": "^1",
+                "universal-cookie": "^6"
+            },
+            "peerDependenciesMeta": {
+                "async-validator": {
+                    "optional": true
+                },
+                "axios": {
+                    "optional": true
+                },
+                "change-case": {
+                    "optional": true
+                },
+                "drauu": {
+                    "optional": true
+                },
+                "focus-trap": {
+                    "optional": true
+                },
+                "fuse.js": {
+                    "optional": true
+                },
+                "idb-keyval": {
+                    "optional": true
+                },
+                "jwt-decode": {
+                    "optional": true
+                },
+                "nprogress": {
+                    "optional": true
+                },
+                "qrcode": {
+                    "optional": true
+                },
+                "sortablejs": {
+                    "optional": true
+                },
+                "universal-cookie": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitepress/node_modules/@vueuse/integrations/node_modules/vue-demi": {
+            "version": "0.14.8",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+            "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitepress/node_modules/axios": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/vitepress/node_modules/rollup": {
@@ -25484,12 +25527,12 @@
             }
         },
         "node_modules/vitepress/node_modules/vite": {
-            "version": "5.2.13",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.13.tgz",
-            "integrity": "sha512-SSq1noJfY9pR3I1TUENL3rQYDQCFqgD+lM6fTRAM8Nv6Lsg5hDLaXkjETVeBt+7vZBCMoibD+6IWnT2mJ+Zb/A==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.1.tgz",
+            "integrity": "sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.20.1",
+                "esbuild": "^0.21.3",
                 "postcss": "^8.4.38",
                 "rollup": "^4.13.0"
             },
@@ -25539,16 +25582,16 @@
             }
         },
         "node_modules/vue": {
-            "version": "3.4.27",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
-            "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+            "version": "3.4.29",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.29.tgz",
+            "integrity": "sha512-8QUYfRcYzNlYuzKPfge1UWC6nF9ym0lx7mpGVPJYNhddxEf3DD0+kU07NTL0sXuiT2HuJuKr/iEO8WvXvT0RSQ==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.4.27",
-                "@vue/compiler-sfc": "3.4.27",
-                "@vue/runtime-dom": "3.4.27",
-                "@vue/server-renderer": "3.4.27",
-                "@vue/shared": "3.4.27"
+                "@vue/compiler-dom": "3.4.29",
+                "@vue/compiler-sfc": "3.4.29",
+                "@vue/runtime-dom": "3.4.29",
+                "@vue/server-renderer": "3.4.29",
+                "@vue/shared": "3.4.29"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -26477,9 +26520,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-            "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "types": "dist/types/index.d.ts",
     "private": true,
     "dependencies": {
-        "@cloudscape-design/components": "^3.0.580",
+        "@cloudscape-design/components": "3.0.638",
         "@cloudscape-design/components-themeable": "^3.0.595",
         "@cloudscape-design/design-tokens": "^3.0.34",
         "@cloudscape-design/global-styles": "^1.0.25",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,6 @@ export default function App () {
                         toolsClose: 'Close help panel',
                         toolsToggle: 'Open help panel',
                     }}
-                    headerVariant='high-contrast'
                     contentHeader={<Header />}
                     headerSelector='#topBanner'
                     footerSelector='#bottomBanner'

--- a/frontend/src/shared/layout/content-layout.tsx
+++ b/frontend/src/shared/layout/content-layout.tsx
@@ -22,7 +22,7 @@ export const ContentLayout = (props: ContentLayoutProps) => {
     
 
     return (
-        <CloudscapeContentLayout headerVariant='high-contrast' {...props}/>
+        <CloudscapeContentLayout {...props}/>
     );
 };
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Revert cloudscape version to 3.0.368 which is right before they change default header styles.
- Still leave the custom ContentLayout so that its easier to revert changes in this PR after release.
- Still leave in the changes to the admin config page to maintain custom container for tabs and high-contrast header. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
