### PR TITLE
Make labeling team required for labeling job

### DIFF
--- a/frontend/src/entities/jobs/labeling/create/labeling-job-create.tsx
+++ b/frontend/src/entities/jobs/labeling/create/labeling-job-create.tsx
@@ -144,6 +144,9 @@ export function LabelingJobCreate () {
                         message:
                             'Task expiration time must be between 1 minute and 30 days (inclusive).',
                     }),
+                WorkteamArn: z.string().min(1, {
+                    message: 'A labeling team must be selected.',
+                })
             }),
         }),
         taskSelection: z.any(),


### PR DESCRIPTION
There is an issue where labeling team isn't required in the UI for creating a labeling job. This is required in the BE though. Updating the FE to make the field required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
