### PR TITLE
Install doc improvement

### DIFF
--- a/frontend/docs/admin-guide/install.md
+++ b/frontend/docs/admin-guide/install.md
@@ -587,7 +587,7 @@ In order to create the default {{ $params.APPLICATION_NAME }} notebook policy an
 4. Click next again and enter a name for this policy. You can name the policy whatever you'd like, but ensure you remember it as you'll need it when creating the role.
 5. After the policy has been created, you are now ready to create the role. From the IAM Service page, click "Roles" on the left-hand side.
 6. Click the "Create role" button and then click the "Custom trust policy" card under "Trusted entity type".
-7. Copy and paste the following content into the "Custom trust policy" text area: 
+7. Copy and paste the following content into the "Custom trust policy" text area:
 
 ```JSON
 {
@@ -605,7 +605,7 @@ In order to create the default {{ $params.APPLICATION_NAME }} notebook policy an
 ```
 
 8. Click the next button and then select the checkbox next to the name of the policy you created in step 4 above.
-9. After selecting the checkbox for the policy, click next and enter a name for the role. You can name the role whatever you'd like. Optionally add a description and tags, and then click "Create role".
+9. After selecting the checkbox for the policy, click next and enter a name for the role. The name should begin with "MLSpace" (Ex: MLSpaceNotebookRole). Optionally add a description and tags, and then click "Create role".
 10. Once the role has been created, record the role ARN as we'll need to use it later.
 
 #### App Role

--- a/frontend/src/entities/dataset/create/dataset-create.tsx
+++ b/frontend/src/entities/dataset/create/dataset-create.tsx
@@ -230,7 +230,7 @@ export function DatasetCreate () {
                                             header='Dataset Access Limitations'
                                         >
                                             Dataset Type is used as a convention to organize data within
-                                            S3 but <strong>does not</strong> prevent other ${window.env.APPLICATION_NAME} users
+                                            S3 but <strong>does not</strong> prevent other {window.env.APPLICATION_NAME} users
                                             from accessing data. Making a &quot;Private&quot; or
                                             &quot;Project&quot; dataset is merely a convention and does
                                             not enforce access control.

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -87,7 +87,7 @@ export class IAMStack extends Stack {
         );
 
         // Role names
-        const mlspaceSystemRoleName = 'mlspaceSystemRole';
+        const mlspaceSystemRoleName = 'mlspace-system-role';
         const mlSpaceNotebookRoleName = 'mlspace-notebook-role';
 
         const invertedBooleanConditions = (conditions: {[key: string]: string}) => Object.fromEntries(Object.entries(conditions).map(([key, value]) => {


### PR DESCRIPTION
*Description of changes:* The notebook role must be named something like MLSpaceNotebookRole in order for the app and system policies `iam:passRole` condition that the resource be named "MLSpace*" be fulfilled.

I also noticed an extra "$" in the alert for creating a dataset and removed that.

Ex:
```
        {
            "Condition": {
                "StringEquals": {
                    "iam:PassedToService": "sagemaker.amazonaws.com"
                }
            },
            "Action": "iam:PassRole",
            "Resource": "arn:{AWS_PARTITION}:iam::{AWS_ACCOUNT}:role/MLSpace*",
            "Effect": "Allow"
        },
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
