### PR TITLE
Mention quota in access denied error

### DIFF
--- a/backend/src/ml_space_lambda/utils/common_functions.py
+++ b/backend/src/ml_space_lambda/utils/common_functions.py
@@ -222,7 +222,7 @@ def generate_exception_response(e, status_code=400):
             },
             {
                 "Codes": ["AccessDeniedException"],
-                "FriendlyMessage": "An administrator or owner has restricted access to this resource or this account has hit its service limit for this resource. If you need access or to increase the limits, please contact a system administrator or owner of the resource for assistance",
+                "FriendlyMessage": "An administrator or owner has restricted access to this resource or this account has hit its service limit for this resource. If you need access or to increase the limits, please contact a system administrator or owner of the resource for assistance.",
             },
         ]
 
@@ -230,7 +230,7 @@ def generate_exception_response(e, status_code=400):
             if e.response["Error"]["Code"] in errorType["Codes"] and (
                 "MatchStrings" not in errorType or any(error in error_msg for error in errorType["MatchStrings"])
             ):
-                e = f"{errorType['FriendlyMessage']}. Full message: {error_msg}"
+                e = f"{errorType['FriendlyMessage']} Full message: {error_msg}"
                 break
 
         logger.exception(e)

--- a/backend/src/ml_space_lambda/utils/common_functions.py
+++ b/backend/src/ml_space_lambda/utils/common_functions.py
@@ -222,7 +222,7 @@ def generate_exception_response(e, status_code=400):
             },
             {
                 "Codes": ["AccessDeniedException"],
-                "FriendlyMessage": "An administrator or owner has restricted access to this resource. If you need access, please contact a system administrator or owner of the resource for assistance",
+                "FriendlyMessage": "An administrator or owner has restricted access to this resource or this account has hit its service limit for this resource. If you need access or to increase the limits, please contact a system administrator or owner of the resource for assistance",
             },
         ]
 
@@ -230,7 +230,7 @@ def generate_exception_response(e, status_code=400):
             if e.response["Error"]["Code"] in errorType["Codes"] and (
                 "MatchStrings" not in errorType or any(error in error_msg for error in errorType["MatchStrings"])
             ):
-                e = f"{errorType['FriendlyMessage']} Full message: {error_msg}"
+                e = f"{errorType['FriendlyMessage']}. Full message: {error_msg}"
                 break
 
         logger.exception(e)

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -87,7 +87,7 @@ export class IAMStack extends Stack {
         );
 
         // Role names
-        const mlspaceSystemRoleName = 'mlspaceSystemRole';
+        const mlspaceSystemRoleName = 'mlspace-system-role';
         const mlSpaceNotebookRoleName = 'mlspace-notebook-role';
 
         const invertedBooleanConditions = (conditions: {[key: string]: string}) => Object.fromEntries(Object.entries(conditions).map(([key, value]) => {

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -87,7 +87,7 @@ export class IAMStack extends Stack {
         );
 
         // Role names
-        const mlspaceSystemRoleName = 'mlspace-system-role';
+        const mlspaceSystemRoleName = 'mlspaceSystemRole';
         const mlSpaceNotebookRoleName = 'mlspace-notebook-role';
 
         const invertedBooleanConditions = (conditions: {[key: string]: string}) => Object.fromEntries(Object.entries(conditions).map(([key, value]) => {


### PR DESCRIPTION
*Description of changes:* When trying to start a training job with a GPU instance that you don't have a high enough service limit for, instead of giving an actually useful error boto3 will give a blanket `AccessDeniedException` and tell you that you lack CreateTrainingJob permissions.

This change will reword the user-friendly error message so that it also mentions the possibility of the customer hitting their service limits.

Also added a period to the displayed error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
