### PR TITLE
Bug: ARNs for Instance contraint policies not being passed to lambdas correctly

### DIFF
--- a/bin/mlspace-cdk.ts
+++ b/bin/mlspace-cdk.ts
@@ -113,6 +113,8 @@ const coreStack = new CoreStack(app, 'mlspace-core', {
     encryptionKey: kmsStack.masterKey,
     mlSpaceAppRole,
     mlSpaceNotebookRole,
+    mlspaceEndpointConfigInstanceConstraintPolicy,
+    mlspaceJobInstanceConstraintPolicy,
     mlSpaceVPC,
     lambdaSecurityGroups: [vpcStack.vpcSecurityGroup],
     mlSpaceDefaultSecurityGroupId: vpcStack.vpcSecurityGroupId,

--- a/lib/stacks/infra/core.ts
+++ b/lib/stacks/infra/core.ts
@@ -21,7 +21,7 @@ import { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
 import { CfnSecurityConfiguration } from 'aws-cdk-lib/aws-emr';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
-import { Effect, IRole, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Effect, IManagedPolicy, IRole, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { IKey } from 'aws-cdk-lib/aws-kms';
 import { Code, Function } from 'aws-cdk-lib/aws-lambda';
 import {
@@ -53,6 +53,8 @@ export type CoreStackProps = {
     readonly encryptionKey: IKey;
     readonly mlSpaceAppRole: IRole;
     readonly mlSpaceNotebookRole: IRole;
+    readonly mlspaceEndpointConfigInstanceConstraintPolicy?: IManagedPolicy,
+    readonly mlspaceJobInstanceConstraintPolicy?: IManagedPolicy,
     readonly mlSpaceVPC: IVpc;
     readonly mlSpaceDefaultSecurityGroupId: string;
     readonly isIso?: boolean;
@@ -237,8 +239,8 @@ export class CoreStack extends Stack {
             role: props.mlSpaceAppRole,
             environment: {
                 APP_CONFIG_TABLE: props.mlspaceConfig.APP_CONFIGURATION_TABLE_NAME,
-                ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN: props.mlspaceConfig.ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN,
-                JOB_INSTANCE_CONSTRAINT_POLICY_ARN: props.mlspaceConfig.JOB_INSTANCE_CONSTRAINT_POLICY_ARN,
+                ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN: props.mlspaceEndpointConfigInstanceConstraintPolicy?.managedPolicyArn || '',
+                JOB_INSTANCE_CONSTRAINT_POLICY_ARN: props.mlspaceJobInstanceConstraintPolicy?.managedPolicyArn || '',
                 SYSTEM_TAG: props.mlspaceConfig.SYSTEM_TAG,
                 MANAGE_IAM_ROLES: props.mlspaceConfig.MANAGE_IAM_ROLES ? 'True' : '',
             },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ARNs for the instance constraint policies (endpoint-config and training/hpo/transform jobs) weren't being set as environment variables correctly for lambda's that used them. It was only working when the ARNs were explicitly provided, not when the policies themselves were created through CDK.

> [!IMPORTANT]  
> This affects 1.5 and should be back-ported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
