### PR TITLE
Bug: instance constraint issues

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -4,9 +4,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/**" ]
 
 permissions:
   contents: read

--- a/backend/src/ml_space_lambda/initial_app_config/lambda_function.py
+++ b/backend/src/ml_space_lambda/initial_app_config/lambda_function.py
@@ -16,6 +16,7 @@ import logging
 
 import boto3
 
+from ml_space_lambda.app_configuration.policy_helper.notebook import update_instance_constraint_policies
 from ml_space_lambda.data_access_objects.app_configuration import AppConfigurationDAO
 from ml_space_lambda.enums import ServiceType
 from ml_space_lambda.metadata.lambda_functions import get_compute_types
@@ -46,6 +47,7 @@ def lambda_handler(event, context):
     ]
 
     app_configuration_dao.update(config)
+    update_instance_constraint_policies(config, context)
     update_dynamic_roles_with_notebook_policies()
 
     generate_html_response(200, "Successfully updated app config")

--- a/backend/test/initial_app_config/test_populate_configuration.py
+++ b/backend/test/initial_app_config/test_populate_configuration.py
@@ -56,20 +56,28 @@ MOCK_COMPUTE_TYPES = {
 
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.update_dynamic_roles_with_notebook_policies")
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.get_compute_types")
+@mock.patch("ml_space_lambda.initial_app_config.lambda_function.update_instance_constraint_policies")
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.app_configuration_dao")
-def test_initial_config_success(mock_app_config_dao, mock_compute_types, update_dynamic_roles_with_notebook_policies):
+def test_initial_config_success(
+    mock_app_config_dao,
+    mock_update_instance_constraint_policies,
+    mock_compute_types,
+    update_dynamic_roles_with_notebook_policies,
+):
     mock_app_config_dao.get.return_value = [generate_config()]
     mock_app_config_dao.update.return_value = None
     mock_compute_types.return_value = MOCK_COMPUTE_TYPES
 
     lambda_handler(mock_event, mock_context)
 
-    # The outgoing config should now contain the instance types for each service
-    mock_app_config_dao.update.assert_called_with(
-        generate_config(
-            notebook_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["InstanceType"],
-            endpoint_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["ProductionVariantInstanceType"],
-            training_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TrainingInstanceType"],
-            transform_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TransformInstanceType"],
-        )
+    generated_config = generate_config(
+        notebook_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["InstanceType"],
+        endpoint_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["ProductionVariantInstanceType"],
+        training_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TrainingInstanceType"],
+        transform_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TransformInstanceType"],
     )
+
+    # The outgoing config should now contain the instance types for each service
+    mock_app_config_dao.update.assert_called_with(generated_config)
+
+    mock_update_instance_constraint_policies.assert_called_with(generated_config, mock_context)

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -1052,8 +1052,8 @@ export class IAMStack extends Stack {
                 assumedBy: appPolicyAllowPrinciples,
                 managedPolicies: [
                     appPolicy, 
-                    notebookPolicy,
-                    ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
+                    ...notebookManagedPolicies,
+                    ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
                 ],
                 description:
                     'Allows ML Space Application to access necessary AWS services (S3, SQS, DynamoDB, ...)',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current notebook policy no longer grants permission for certain actions when `MANAGE_IAM_ROLES` is set to `true`. Instead, the notebook role inherits these permissions through the endpoint configuration and jobs instance constraint policies. As these policies are newly introduced, they were not included in the app-role when created with CDK. Consequently, only the notebook policy was added to the app-role, resulting in insufficient permissions.

- added instance constraint policies to CDK generated app role
- updated initial app config lambda to populate instance constraint policies
- updated tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
