### PR TITLE
Bug: instance constraint issues

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -4,9 +4,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/**" ]
 
 permissions:
   contents: read

--- a/backend/src/ml_space_lambda/initial_app_config/lambda_function.py
+++ b/backend/src/ml_space_lambda/initial_app_config/lambda_function.py
@@ -18,7 +18,7 @@ import boto3
 
 from ml_space_lambda.app_configuration.policy_helper.notebook import update_instance_constraint_policies
 from ml_space_lambda.data_access_objects.app_configuration import AppConfigurationDAO
-from ml_space_lambda.enums import ServiceType
+from ml_space_lambda.enums import EnvVariable, ServiceType
 from ml_space_lambda.metadata.lambda_functions import get_compute_types
 from ml_space_lambda.utils.common_functions import generate_html_response
 from ml_space_lambda.utils.iam_manager import DYNAMIC_USER_ROLE_TAG, IAMManager
@@ -31,6 +31,7 @@ iam = boto3.client("iam", config=retry_config)
 
 
 def lambda_handler(event, context):
+    env_vars = get_environment_variables()
     instances = get_compute_types()
     resp = app_configuration_dao.get("global")
     config = resp[0]
@@ -47,23 +48,22 @@ def lambda_handler(event, context):
     ]
 
     app_configuration_dao.update(config)
-    update_instance_constraint_policies(config, context)
-    update_dynamic_roles_with_notebook_policies()
+
+    # if not using dynamic roles then there is no need to update these roles/policies
+    if env_vars[EnvVariable.MANAGE_IAM_ROLES]:
+        update_instance_constraint_policies(config, context)
+        update_dynamic_roles_with_notebook_policies()
 
     generate_html_response(200, "Successfully updated app config")
 
 
 def update_dynamic_roles_with_notebook_policies():
     env_vars = get_environment_variables()
-
-    if env_vars["MANAGE_IAM_ROLES"]:
-        return
-
     iam_manager = IAMManager(iam)
     role_names = iam_manager.find_dynamic_user_roles()
     policy_arns = [
-        env_vars["JOB_INSTANCE_CONSTRAINT_POLICY_ARN"],
-        env_vars["ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN"],
+        env_vars[EnvVariable.JOB_INSTANCE_CONSTRAINT_POLICY_ARN],
+        env_vars[EnvVariable.ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN],
     ]
     iam_manager.attach_policies_to_roles(policy_arns, role_names)
 

--- a/backend/src/ml_space_lambda/initial_app_config/lambda_function.py
+++ b/backend/src/ml_space_lambda/initial_app_config/lambda_function.py
@@ -16,6 +16,7 @@ import logging
 
 import boto3
 
+from ml_space_lambda.app_configuration.policy_helper.notebook import update_instance_constraint_policies
 from ml_space_lambda.data_access_objects.app_configuration import AppConfigurationDAO
 from ml_space_lambda.enums import ServiceType
 from ml_space_lambda.metadata.lambda_functions import get_compute_types
@@ -46,6 +47,7 @@ def lambda_handler(event, context):
     ]
 
     app_configuration_dao.update(config)
+    update_instance_constraint_policies(config, context)
     update_dynamic_roles_with_notebook_policies()
 
     generate_html_response(200, "Successfully updated app config")

--- a/backend/test/app_configuration/test_update_configuration.py
+++ b/backend/test/app_configuration/test_update_configuration.py
@@ -148,19 +148,24 @@ def test_update_config_success(
     assert lambda_handler(mock_event, mock_context) == expected_response
 
 
-# @mock.pathc("ml_space_lambda.app_configuration.lambda_functions.suspend_all_of_type")
+@mock.patch("ml_space_lambda.app_configuration.lambda_functions.suspend_all_of_type")
 @mock.patch(
     "ml_space_lambda.app_configuration.policy_helper.active_service_policy_manager.ActiveServicePolicyManager.update_activated_services_policy"
 )
 @mock.patch("ml_space_lambda.app_configuration.lambda_functions.update_instance_constraint_policies")
 @mock.patch("ml_space_lambda.app_configuration.lambda_functions.app_configuration_dao")
 def test_update_config_success_with_suspend_resources_issues(
-    mock_app_config_dao, mock_update_instance_constraint_policies, mock_update_activated_services_policy
+    mock_app_config_dao, mock_update_instance_constraint_policies, mock_update_activated_services_policy, suspend_all_of_type
 ):
     version_id = 1
     mock_event = generate_event("global", version_id)
     mock_app_config_dao.create.return_value = None
     mock_update_activated_services_policy.return_value = [ResourceType.BATCH_TRANSLATE_JOB]
+
+    def raise_exception(event, context):
+        raise Exception()
+
+    suspend_all_of_type.side_effect = raise_exception
 
     # Add 1 to version ID as it's incremented as part of the update
     success_response = "Successfully updated configuration for global, version 2, but issues were encountered when suspending resources for a deactivated service. Please contact your system administrator for assistance in suspending resources for deactivated services."

--- a/backend/test/initial_app_config/test_populate_configuration.py
+++ b/backend/test/initial_app_config/test_populate_configuration.py
@@ -56,20 +56,28 @@ MOCK_COMPUTE_TYPES = {
 
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.update_dynamic_roles_with_notebook_policies")
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.get_compute_types")
+@mock.patch("ml_space_lambda.initial_app_config.lambda_function.update_instance_constraint_policies")
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.app_configuration_dao")
-def test_initial_config_success(mock_app_config_dao, mock_compute_types, update_dynamic_roles_with_notebook_policies):
+def test_initial_config_success(
+    mock_app_config_dao,
+    mock_update_instance_constraint_policies,
+    mock_compute_types,
+    update_dynamic_roles_with_notebook_policies,
+):
     mock_app_config_dao.get.return_value = [generate_config()]
     mock_app_config_dao.update.return_value = None
     mock_compute_types.return_value = MOCK_COMPUTE_TYPES
 
     lambda_handler(mock_event, mock_context)
 
-    # The outgoing config should now contain the instance types for each service
-    mock_app_config_dao.update.assert_called_with(
-        generate_config(
-            notebook_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["InstanceType"],
-            endpoint_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["ProductionVariantInstanceType"],
-            training_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TrainingInstanceType"],
-            transform_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TransformInstanceType"],
-        )
+    generated_config = generate_config(
+        notebook_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["InstanceType"],
+        endpoint_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["ProductionVariantInstanceType"],
+        training_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TrainingInstanceType"],
+        transform_list=MOCK_COMPUTE_TYPES["InstanceTypes"]["TransformInstanceType"],
     )
+
+    # The outgoing config should now contain the instance types for each service
+    mock_app_config_dao.update.assert_called_with(generated_config)
+
+    mock_update_instance_constraint_policies.assert_called_with(generated_config, mock_context)

--- a/backend/test/initial_app_config/test_populate_configuration.py
+++ b/backend/test/initial_app_config/test_populate_configuration.py
@@ -16,9 +16,10 @@
 
 from unittest import mock
 
-from ml_space_lambda.enums import ServiceType
+from ml_space_lambda.enums import EnvVariable, ServiceType
+from ml_space_lambda.utils import mlspace_config
 
-TEST_ENV_CONFIG = {"AWS_DEFAULT_REGION": "us-east-1"}
+TEST_ENV_CONFIG = {"AWS_DEFAULT_REGION": "us-east-1", EnvVariable.MANAGE_IAM_ROLES.value: "True"}
 
 mock_context = mock.Mock()
 mock_event = mock.Mock()
@@ -54,6 +55,7 @@ MOCK_COMPUTE_TYPES = {
 }
 
 
+@mock.patch.dict("os.environ", TEST_ENV_CONFIG, clear=True)
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.update_dynamic_roles_with_notebook_policies")
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.get_compute_types")
 @mock.patch("ml_space_lambda.initial_app_config.lambda_function.update_instance_constraint_policies")
@@ -64,6 +66,8 @@ def test_initial_config_success(
     mock_compute_types,
     update_dynamic_roles_with_notebook_policies,
 ):
+    mlspace_config.env_variables = {}
+
     mock_app_config_dao.get.return_value = [generate_config()]
     mock_app_config_dao.update.return_value = None
     mock_compute_types.return_value = MOCK_COMPUTE_TYPES

--- a/backend/test/initial_app_config/test_update_dynamic_roles_with_notebook_policies.py
+++ b/backend/test/initial_app_config/test_update_dynamic_roles_with_notebook_policies.py
@@ -16,14 +16,16 @@
 
 from unittest import mock
 
+from ml_space_lambda.enums import EnvVariable
 from ml_space_lambda.utils import mlspace_config
 from ml_space_lambda.utils.iam_manager import DYNAMIC_USER_ROLE_TAG
 
 TEST_ENV_CONFIG = {
-    "AWS_DEFAULT_REGION": "us-east-1",
-    "SYSTEM_TAG": "MLSpace",
-    "JOB_INSTANCE_CONSTRAINT_POLICY_ARN": "arn:aws:iam::123456789012:policy/notebook-job-constraints",
-    "ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN": "arn:aws:iam::123456789012:policy/notebook-endpoint-constraints",
+    EnvVariable.AWS_DEFAULT_REGION.value: "us-east-1",
+    EnvVariable.SYSTEM_TAG.value: "MLSpace",
+    EnvVariable.JOB_INSTANCE_CONSTRAINT_POLICY_ARN.value: "arn:aws:iam::123456789012:policy/notebook-job-constraints",
+    EnvVariable.ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN.value: "arn:aws:iam::123456789012:policy/notebook-endpoint-constraints",
+    EnvVariable.MANAGE_IAM_ROLES.value: "True",
 }
 
 mock_context = mock.Mock()
@@ -76,19 +78,19 @@ def test_initial_config_success(mock_iam):
         [
             mock.call(
                 RoleName="MLSpace-myproject3-0fb265a4573777a0442ec4c6edeaf707216a2f5b16aa",
-                PolicyArn=TEST_ENV_CONFIG["JOB_INSTANCE_CONSTRAINT_POLICY_ARN"],
+                PolicyArn=TEST_ENV_CONFIG[EnvVariable.JOB_INSTANCE_CONSTRAINT_POLICY_ARN.value],
             ),
             mock.call(
                 RoleName="MLSpace-myproject3-0fb265a4573777a0442ec4c6edeaf707216a2f5b16aa",
-                PolicyArn=TEST_ENV_CONFIG["ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN"],
+                PolicyArn=TEST_ENV_CONFIG[EnvVariable.ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN.value],
             ),
             mock.call(
                 RoleName="MLSpace-myproject4-0fb265a4573777a0442ec4c6edeaf707216a2f5b16aa",
-                PolicyArn=TEST_ENV_CONFIG["JOB_INSTANCE_CONSTRAINT_POLICY_ARN"],
+                PolicyArn=TEST_ENV_CONFIG[EnvVariable.JOB_INSTANCE_CONSTRAINT_POLICY_ARN.value],
             ),
             mock.call(
                 RoleName="MLSpace-myproject4-0fb265a4573777a0442ec4c6edeaf707216a2f5b16aa",
-                PolicyArn=TEST_ENV_CONFIG["ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN"],
+                PolicyArn=TEST_ENV_CONFIG[EnvVariable.ENDPOINT_CONFIG_INSTANCE_CONSTRAINT_POLICY_ARN.value],
             ),
         ]
     )

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -1052,8 +1052,8 @@ export class IAMStack extends Stack {
                 assumedBy: appPolicyAllowPrinciples,
                 managedPolicies: [
                     appPolicy, 
-                    notebookPolicy,
-                    ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
+                    ...notebookManagedPolicies,
+                    ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
                 ],
                 description:
                     'Allows ML Space Application to access necessary AWS services (S3, SQS, DynamoDB, ...)',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current notebook policy no longer grants permission for certain actions when `MANAGE_IAM_ROLES` is set to `true`. Instead, the notebook role inherits these permissions through the endpoint configuration and jobs instance constraint policies. As these policies are newly introduced, they were not included in the app-role when created with CDK. Consequently, only the notebook policy was added to the app-role, resulting in insufficient permissions.

- added instance constraint policies to CDK generated app role
- updated initial app config lambda to populate instance constraint policies
- updated tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
