### PR TITLE
EMR detail page race condition fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If the config-helper doesn't provide the level of customization you need for you
 | SYSTEM_BANNER_BACKGROUND_COLOR | The background color of the system banner if enabled. Supports valid CSS colors including predefined color names, hex values, and rgb values. | `black` |
 | SYSTEM_BANNER_TEXT_COLOR | The color of the text displayed in the system banner if enabled. Supports valid CSS colors including predefined color names, hex values, and rgb values. | `white` |
 | RESOURCE_TERMINATION_INTERVAL | Interval (in minutes) to run the resource termination cleanup lambda | `60` |
-| BACKGROUND_REFRESH_INTERVAL | Interval (in minutes) to run background resource data updates | `60` |
+| BACKGROUND_REFRESH_INTERVAL | Interval (in seconds) to run background resource data updates | `60` |
 | DATASETS_TABLE_NAME |  Dynamo DB table to hold dataset related metadata | `mlspace-datasets` |
 | PROJECTS_TABLE_NAME |  Dynamo DB table to hold project related metadata | `mlspace-projects` |
 | PROJECT_USERS_TABLE_NAME |  Dynamo DB table to hold project membership related metadata. Including permissions and project/user specific IAM role data. | `mlspace-project-users` |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@amzn/mlspace",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@amzn/mlspace",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "dependencies": {
                 "@cloudscape-design/components": "3.0.638",
                 "@cloudscape-design/components-themeable": "^3.0.595",

--- a/frontend/src/entities/emr/detail/emr-clusters-detail.tsx
+++ b/frontend/src/entities/emr/detail/emr-clusters-detail.tsx
@@ -124,7 +124,7 @@ function EMRDetail () {
                 header={
                     <Header variant='h1'>
                         {' '}
-                        Cluster: {cluster.Name} ({clusterId}){' '}
+                        Cluster: {clusterName} ({clusterId}){' '}
                     </Header>
                 }
             >

--- a/frontend/src/entities/emr/emr.reducer.ts
+++ b/frontend/src/entities/emr/emr.reducer.ts
@@ -15,7 +15,7 @@
 */
 
 import axios from '../../shared/util/axios-utils';
-import { createSlice, createAsyncThunk, isFulfilled, isPending } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk, isFulfilled, isPending, isRejected } from '@reduxjs/toolkit';
 import { EMRCluster } from './emr.model';
 import { PagedResponsePayload, ServerRequestProps } from '../../shared/util/table-utils';
 import { addPagingParams } from '../../shared/util/url-utils';
@@ -143,6 +143,13 @@ export const EMRClusterSlice = createSlice({
                 return {
                     ...state,
                     loadingCluster: true,
+                };
+            })
+            .addMatcher(isRejected(getEMRCluster), (state) => {
+                return {
+                    ...state,
+                    loadingCluster: true, // Continue loading until a call goes through
+                    cluster: {} as EMRCluster,
                 };
             })
             .addMatcher(isPending(listEMRClusters), (state) => {

--- a/frontend/src/shared/util/hooks.ts
+++ b/frontend/src/shared/util/hooks.ts
@@ -26,7 +26,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
  * @param {Array} deps - The dependencies of the action function
  * @param {boolean} condition - A condition that must be true for the action to run
 */
-export function useBackgroundRefresh (action: () => void, deps: readonly unknown[] = [], condition = true): boolean {
+export function useBackgroundRefresh (action: () => void, deps: readonly unknown[] = [], condition = true, interval = window.env.BACKGROUND_REFRESH_INTERVAL): boolean {
     const callbackAction = useCallback(action, [action, ...deps]);
     const [isBackgroundRefreshing, setIsBackgroundRefreshing] = useState(false);
 
@@ -46,13 +46,13 @@ export function useBackgroundRefresh (action: () => void, deps: readonly unknown
                 setTimeout(() => {
                     setIsBackgroundRefreshing(false);
                 }, waitTime);
-            }, (window.env.BACKGROUND_REFRESH_INTERVAL || 60) * 1000);
+            }, (interval || 60) * 1000);
             
             return () => {
                 clearInterval(timerId);
             };
         }
-    }, [callbackAction, condition]);
+    }, [callbackAction, condition, interval]);
     return isBackgroundRefreshing;
 }
 

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -1052,7 +1052,7 @@ export class IAMStack extends Stack {
                 assumedBy: appPolicyAllowPrinciples,
                 managedPolicies: [
                     appPolicy, 
-                    notebookPolicy,
+                    ...notebookManagedPolicies,
                     ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
                 ],
                 description:


### PR DESCRIPTION
*Description of changes:* When you create a cluster it will navigate you to the details page and immediately try to GET that cluster.

For reasons outside of MLSpace (nothing in our authorizer or lambda logs) this is returning a 403... probably because EMR is still setting up that cluster and it doesn't exist in the EMR ecosystem yet.

This fix will handle this issue by continuing to display a "loading" page while we refresh every 3 seconds and continuously try to fetch the cluster (in my testing it typically takes 3-9 seconds to populate).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
