### PR TITLE
Fixes invalid instance type check for HPO/Training

### DIFF
--- a/backend/src/ml_space_lambda/hpo_job/lambda_functions.py
+++ b/backend/src/ml_space_lambda/hpo_job/lambda_functions.py
@@ -39,8 +39,9 @@ resource_metadata_dao = ResourceMetadataDAO()
 def _normalize_job_definition(definition, iam_role, param_file):
     definition["RoleArn"] = iam_role
     definition["OutputDataConfig"]["KmsKeyId"] = param_file["pSMSKMSKeyId"]
+    instance_type = definition["ResourceConfig"]["InstanceType"].removeprefix("ml.")
     definition["ResourceConfig"]["VolumeKmsKeyId"] = (
-        "" if definition["ResourceConfig"]["InstanceType"] in kms_unsupported_instances() else param_file["pSMSKMSKeyId"]
+        "" if instance_type in kms_unsupported_instances() else param_file["pSMSKMSKeyId"]
     )
     definition["VpcConfig"] = {
         "SecurityGroupIds": param_file["pSMSSecurityGroupId"],

--- a/backend/src/ml_space_lambda/training_job/lambda_functions.py
+++ b/backend/src/ml_space_lambda/training_job/lambda_functions.py
@@ -73,6 +73,7 @@ def create(event, context):
     if "AlgorithmName" in algorithm_specs and "TrainingImage" in algorithm_specs:
         del algorithm_specs["AlgorithmName"]
 
+    instance_type = resource_config["InstanceType"].removeprefix("ml.")
     training_job_definition = dict(
         TrainingJobName=training_job_name,
         HyperParameters=hyper_parameters,
@@ -87,9 +88,7 @@ def create(event, context):
             "InstanceType": resource_config["InstanceType"],
             "InstanceCount": int(resource_config["InstanceCount"]),
             "VolumeSizeInGB": int(resource_config["VolumeSizeInGB"]),
-            "VolumeKmsKeyId": (
-                "" if resource_config["InstanceType"] in kms_unsupported_instances() else param_file["pSMSKMSKeyId"]
-            ),
+            "VolumeKmsKeyId": ("" if instance_type in kms_unsupported_instances() else param_file["pSMSKMSKeyId"]),
         },
         VpcConfig={
             "SecurityGroupIds": param_file["pSMSSecurityGroupId"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Training/HPO jobs cannot use KMS keys for volume encryption when launched on instance types that provide their own volume encryption. The previous check for this condition was incorrect because it did not account for the `ml.*` prefix used by SageMaker instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
