### PR TITLE
CRUD Groups without in app group user management

### DIFF
--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -254,6 +254,11 @@ def lambda_handler(event, context):
                                 # if user is part of the project, they can view this translate job
                                 if project_user:
                                     policy_statement["Effect"] = "Allow"
+                elif "groupName" in path_params:
+                    if Permission.ADMIN in user.permissions and request_method in ["POST", "PUT", "DELETE"]:
+                        policy_statement["Effect"] = "Allow"
+                    elif request_method == "GET":
+                        policy_statement["Effect"] = "Allow"
                 else:
                     # All other sagemaker resources have the same general handling, GET calls
                     # typically require ADMIN or project membership, PUT/POST/DELETE typically
@@ -298,6 +303,9 @@ def lambda_handler(event, context):
                     # Check if project creation is admin only; if not, anyone can create a project
                     if not app_config.configuration.project_creation.admin_only:
                         policy_statement["Effect"] = "Allow"
+            elif requested_resource == "/group" and request_method == "POST":
+                if Permission.ADMIN in user.permissions:
+                    policy_statement["Effect"] = "Allow"
             elif requested_resource in ["/dataset/presigned-url", "/dataset/create"]:
                 # If this is a request for a dataset related presigned url or for
                 # creating a new dataset, we need to determine the underlying dataset
@@ -361,6 +369,7 @@ def lambda_handler(event, context):
                     "/metadata/subnets",
                     "/translate/list-languages",
                     "/project",
+                    "/group",
                     "/emr",
                     "/emr/applications",
                     "/emr/release",

--- a/frontend/src/entities/group/create/group-create.tsx
+++ b/frontend/src/entities/group/create/group-create.tsx
@@ -1,0 +1,217 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import React, { useMemo, useState } from 'react';
+import { z } from 'zod';
+import { issuesToErrors, useValidationReducer } from '../../../shared/validation';
+import { useAppDispatch } from '../../../config/store';
+import NotificationService from '../../../shared/layout/notification/notification.service';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button, Container, FormField, Header, Input, SpaceBetween, Textarea, } from '@cloudscape-design/components';
+import Form from '@cloudscape-design/components/form';
+import ContentLayout from '../../../shared/layout/content-layout';
+import { createGroup, getGroup, updateGroup } from '../group.reducer';
+
+export type GroupCreateProperties = {
+    isEdit?: boolean;
+};
+
+export function GroupCreate ({isEdit}: GroupCreateProperties) {
+    const dispatch = useAppDispatch();
+    const notificationService = NotificationService(dispatch);
+    const navigate = useNavigate();
+    const {groupName} = useParams();
+    const [initialLoaded, setInitialLoaded] = useState(false);
+
+    const groupSchema = z.object({
+        name: z
+            .string()
+            .min(3, {
+                message: 'Group name must be longer than 3 characters',
+            })
+            .max(24, {
+                message: 'Group name cannot be more than 24 characters',
+            })
+            .regex(/^[a-zA-Z0-9]+$/, {
+                message: 'Group name can only contain alphanumeric characters.',
+            }),
+        description: z
+            .string({
+                invalid_type_error: 'Group description must be a string',
+            })
+            .min(1, {
+                message: 'Group description cannot be empty',
+            })
+            .max(4000, {
+                message: 'Group description cannot be more than 4000 characters.',
+            })
+            .regex(/[ -~]/, {
+                message: 'Group description can only contain printable characters',
+            }),
+    });
+
+    const {state, setState, setFields, touchFields} = useValidationReducer(groupSchema, {
+        validateAll: false,
+        needsValidation: false,
+        form: {
+            name: '',
+            description: '',
+        },
+        touched: {},
+        formErrors: {} as any,
+        formSubmitting: false,
+    });
+
+    useMemo(() => {
+        if (isEdit && !initialLoaded) {
+            setState({formSubmitting: true});
+            dispatch(getGroup(groupName)).then((response) => {
+                if (response.payload) {
+                    setInitialLoaded(true);
+                    setState({
+                        form: {
+                            name: response.payload?.data.group?.name || '',
+                            description: response.payload?.data.group?.description || '',
+                        },
+                        formSubmitting: false
+                    });
+                } else {
+                    navigate('/404');
+                }
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isEdit, groupName, initialLoaded]);
+
+
+    state.formErrors = {};
+    const parseResult = groupSchema.safeParse(state.form);
+    if (!parseResult.success) {
+        state.formErrors = issuesToErrors(
+            parseResult.error.issues,
+            state.validateAll === true ? undefined : state.touched
+        );
+    }
+
+    async function handleSubmit () {
+        setState({formSubmitting: true});
+        let response = null;
+        try {
+            if (!isEdit) {
+                response = await dispatch(createGroup(state.form));
+            } else {
+                response = await dispatch(updateGroup(state.form));
+            }
+            if (response.payload?.status === 200) {
+                notificationService.generateNotification(
+                    `Successfully ${isEdit ? 'updated' : 'created'} group ${state.form.name}`,
+                    'success'
+                );
+                navigate('/admin/groups');
+            } else {
+                notificationService.generateNotification(
+                    `Failed to ${isEdit ? 'update' : 'create'} group ${state.form.name} with error: ${response.error.message}`,
+                    'error'
+                );
+            }
+        } catch (e) {
+            notificationService.generateNotification(
+                `Failed to ${isEdit ? 'update' : 'create'} group ${state.form.name}`,
+                'error'
+            );
+        } finally {
+            setState({formSubmitting: false});
+        }
+    }
+
+    return (
+        <ContentLayout
+            header={
+                <Header
+                    variant='h1'
+                    description={`${window.env.APPLICATION_NAME} allows users to share datasets and projects with ${window.env.APPLICATION_NAME} managed user groups.`}
+                >
+                    {isEdit ? 'Update group' : 'Create group'}
+                </Header>
+            }
+        >
+            <Form
+                actions={
+                    <SpaceBetween direction='horizontal' size='xl'>
+                        <Button
+                            formAction='none'
+                            variant='link'
+                            onClick={() =>
+                                navigate('/admin/groups', {
+                                    state: {prevPath: window.location.hash},
+                                })
+                            }
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            data-cy='submit'
+                            loading={state.formSubmitting}
+                            variant='primary'
+                            onClick={() => {
+                                handleSubmit();
+                            }}
+                            disabled={state.formSubmitting || !parseResult.success}
+                        >
+                            Submit
+                        </Button>
+                    </SpaceBetween>
+                }
+            >
+                <Container header={<Header variant='h2'>Group details</Header>}>
+                    <SpaceBetween direction='vertical' size='m'>
+                        <FormField
+                            description='The name can only contain alphanumeric characters.'
+                            errorText={state.formErrors.name}
+                            label='Group name'
+                        >
+                            <Input
+                                data-cy='name-input'
+                                value={state.form.name!}
+                                onChange={(event) => {
+                                    setFields({'name': event.detail.value});
+                                }}
+                                onBlur={() => touchFields(['name'])}
+                                disabled={isEdit}
+                            />
+                        </FormField>
+                        <FormField
+                            description='Set a description for your group.'
+                            errorText={state.formErrors.description}
+                            label='Group description'
+                        >
+                            <Textarea
+                                data-cy='description-input'
+                                value={state.form.description!}
+                                onChange={(event) => {
+                                    setFields({'description': event.detail.value});
+                                }}
+                                onBlur={() => touchFields(['description'])}
+                            />
+                        </FormField>
+                    </SpaceBetween>
+                </Container>
+            </Form>
+        </ContentLayout>
+    );
+}
+
+export default GroupCreate;

--- a/frontend/src/entities/group/create/index.ts
+++ b/frontend/src/entities/group/create/index.ts
@@ -1,0 +1,19 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import GroupCreate from './group-create';
+
+export default GroupCreate;

--- a/frontend/src/entities/group/detail/group-detail.actions.tsx
+++ b/frontend/src/entities/group/detail/group-detail.actions.tsx
@@ -1,0 +1,129 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Action, Dispatch, ThunkDispatch } from '@reduxjs/toolkit';
+import { ButtonDropdown, ButtonDropdownProps, SpaceBetween } from '@cloudscape-design/components';
+import { useAppDispatch, useAppSelector } from '../../../config/store';
+import { selectCurrentUser } from '../../user/user.reducer';
+import { hasPermission } from '../../../shared/util/permission-utils';
+import { Permission } from '../../../shared/model/user.model';
+import NotificationService from '../../../shared/layout/notification/notification.service';
+import Modal, { ModalProps } from '../../../modules/modal';
+import { deleteGroup } from '../group.reducer';
+import { setDeleteModal } from '../../../modules/modal/modal.reducer';
+
+function GroupDetailActions () {
+    const dispatch = useAppDispatch();
+    const navigate = useNavigate();
+    const nav = (endpoint: string) => navigate(endpoint);
+    const {groupName} = useParams();
+
+    return (
+        <SpaceBetween direction='horizontal' size='xs'>
+            {GroupActionButton(nav, dispatch, groupName)}
+        </SpaceBetween>
+    );
+}
+
+function GroupActionButton (
+    nav: (endpoint: string) => void,
+    dispatch: Dispatch,
+    groupName: string
+) {
+    const actionItems: Array<ButtonDropdownProps.ItemOrGroup> = [];
+    const currentUser = useAppSelector(selectCurrentUser);
+
+    const [modalState, setModalState] = React.useState<Partial<ModalProps>>({
+        visible: false,
+        confirmText: 'Confirm',
+        dismissText: 'Cancel',
+    });
+
+    if (hasPermission(Permission.ADMIN, currentUser.permissions)) {
+        actionItems.push(
+            ...[
+                {text: 'Update', id: 'update_group'},
+                {text: 'Delete', id: 'delete_group'},
+            ]
+        );
+    }
+
+    return (
+        <ButtonDropdown
+            items={actionItems}
+            variant='primary'
+            disabled={groupName === undefined}
+            onItemClick={(e) =>
+                GroupActionHandler(
+                    e,
+                    groupName,
+                    nav,
+                    dispatch,
+                    modalState as ModalProps,
+                    setModalState
+                )
+            }
+        >
+            <Modal {...(modalState as ModalProps)} />
+            Actions
+        </ButtonDropdown>
+    );
+}
+
+const GroupActionHandler = (
+    e: any,
+    groupName: string,
+    nav: (endpoint: string) => void,
+    dispatch: ThunkDispatch<any, any, Action>,
+    modalState: ModalProps,
+    setModalState: (state: Partial<ModalProps>) => void
+) => {
+    const notificationService = NotificationService(dispatch);
+
+    switch (e.detail.id) {
+        case 'update_group':
+            nav(`/admin/groups/edit/${groupName}`);
+            break;
+        case 'delete_group':
+            dispatch(
+                setDeleteModal({
+                    resourceName: 'Group',
+                    resourceType: 'group',
+                    onConfirm: async () =>
+                        dispatch(deleteGroup(groupName!)).then((result) => {
+                            setModalState({
+                                ...modalState,
+                                visible: false,
+                            });
+                            notificationService.showActionNotification(
+                                'delete group',
+                                `Group ${groupName} deleted.`,
+                                result
+                            );
+                            if (result.type.endsWith('/fulfilled')) {
+                                nav('/');
+                            }
+                        }),
+                    description: `This will delete the following group: ${groupName}.`
+                })
+            );
+            break;
+    }
+};
+
+export default GroupDetailActions;

--- a/frontend/src/entities/group/detail/group-detail.tsx
+++ b/frontend/src/entities/group/detail/group-detail.tsx
@@ -1,0 +1,105 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useAppDispatch } from '../../../config/store';
+import { getGroup, getGroupUsers } from '../group.reducer';
+import { Header, SpaceBetween } from '@cloudscape-design/components';
+import DetailsContainer from '../../../modules/details-container';
+import { IGroup } from '../../../shared/model/group.model';
+import ContentLayout from '../../../shared/layout/content-layout';
+import GroupDetailActions from './group-detail.actions';
+import Table from '../../../modules/table';
+import { groupUserColumns, visibleGroupUserColumns } from '../../user/user.columns';
+import { IGroupUser } from '../../../shared/model/groupUser.model';
+import NotificationService from '../../../shared/layout/notification/notification.service';
+
+export function GroupDetail () {
+    const dispatch = useAppDispatch();
+    const navigate = useNavigate();
+    const notificationService = NotificationService(dispatch);
+    const {groupName} = useParams();
+    const [group, setGroup] = useState<IGroup>(null);
+    const [groupUsers, setGroupUsers] = useState<IGroupUser>([]);
+    const [initialLoaded, setInitialLoaded] = useState(false);
+    const [groupUsersLoaded, setGroupUsersLoaded] = useState(true);
+
+    const groupDetails = new Map<string, ReactNode>();
+    groupDetails.set('Name', group?.name);
+    groupDetails.set('Description', group?.description);
+
+    useMemo(() => {
+        if (initialLoaded === false) {
+            dispatch(getGroup(groupName)).then((response) => {
+                if (response.payload) {
+                    setGroup(response.payload.data.group);
+                    setInitialLoaded(true);
+                } else {
+                    navigate('/404');
+                }
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [groupName, initialLoaded]);
+
+    useEffect(() => {
+        if (initialLoaded === true) {
+            dispatch(getGroupUsers(groupName)).then((response) => {
+                if (response.payload) {
+                    setGroupUsers(response.payload.data);
+                } else {
+                    notificationService.generateNotification(
+                        `Failed to fetch ${groupName} users.`,
+                        'error'
+                    );
+                }
+                setGroupUsersLoaded(true);
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initialLoaded, groupName]);
+
+    return (
+        <ContentLayout header={<Header variant='h1'>{groupName}</Header>}>
+            <SpaceBetween direction='vertical' size='xxl'>
+                <DetailsContainer
+                    columns={1}
+                    header='Group details'
+                    actions={GroupDetailActions()}
+                    info={groupDetails}
+                    loading={!initialLoaded}
+                />
+                {/*<Container>*/}
+                <Table
+                    tableName='Group member'
+                    // tableType={tableType}
+                    // actions={actions}
+                    itemNameProperty='user'
+                    trackBy='user'
+                    allItems={groupUsers}
+                    columnDefinitions={groupUserColumns}
+                    visibleColumns={visibleGroupUserColumns}
+                    loadingItems={!groupUsersLoaded}
+                    loadingText='Loading Group members'
+                />
+                {/*</Container>*/}
+            </SpaceBetween>
+        </ContentLayout>
+    );
+}
+
+export default GroupDetail;

--- a/frontend/src/entities/group/detail/group-detail.tsx
+++ b/frontend/src/entities/group/detail/group-detail.tsx
@@ -31,18 +31,18 @@ import NotificationService from '../../../shared/layout/notification/notificatio
 export function GroupDetail () {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
-    const notificationService = NotificationService(dispatch);
     const {groupName} = useParams();
     const [group, setGroup] = useState<IGroup>(null);
     const [groupUsers, setGroupUsers] = useState<IGroupUser>([]);
     const [initialLoaded, setInitialLoaded] = useState(false);
     const [groupUsersLoaded, setGroupUsersLoaded] = useState(true);
+    const notificationService = useMemo(() => NotificationService(dispatch), [dispatch]);
 
     const groupDetails = new Map<string, ReactNode>();
     groupDetails.set('Name', group?.name);
     groupDetails.set('Description', group?.description);
 
-    useMemo(() => {
+    useEffect(() => {
         if (initialLoaded === false) {
             dispatch(getGroup(groupName)).then((response) => {
                 if (response.payload) {
@@ -53,8 +53,7 @@ export function GroupDetail () {
                 }
             });
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [groupName, initialLoaded]);
+    }, [groupName, initialLoaded, dispatch, navigate]);
 
     useEffect(() => {
         if (initialLoaded === true) {
@@ -70,8 +69,7 @@ export function GroupDetail () {
                 setGroupUsersLoaded(true);
             });
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [initialLoaded, groupName]);
+    }, [initialLoaded, groupName, dispatch, notificationService]);
 
     return (
         <ContentLayout header={<Header variant='h1'>{groupName}</Header>}>

--- a/frontend/src/entities/group/detail/index.ts
+++ b/frontend/src/entities/group/detail/index.ts
@@ -1,0 +1,19 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import GroupDetail from './group-detail';
+
+export default GroupDetail;

--- a/frontend/src/entities/group/group.actions.tsx
+++ b/frontend/src/entities/group/group.actions.tsx
@@ -1,0 +1,97 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+import { useAppDispatch } from '../../config/store';
+import { Button, ButtonDropdown, Icon, SpaceBetween } from '@cloudscape-design/components';
+import { deleteGroup, getAllGroups } from './group.reducer';
+import React from 'react';
+import { Action, Dispatch, ThunkDispatch } from '@reduxjs/toolkit';
+import { IGroup } from '../../shared/model/group.model';
+import { setDeleteModal } from '../../modules/modal/modal.reducer';
+import { NavigateFunction, useNavigate } from 'react-router-dom';
+
+function GroupActions (props?: any) {
+    const dispatch = useAppDispatch();
+    const navigate = useNavigate();
+
+    return (
+        <SpaceBetween direction='horizontal' size='xs'>
+            <Button onClick={() => dispatch(getAllGroups())} ariaLabel={'Refresh groups list'}>
+                <Icon name='refresh'/>
+            </Button>
+            {GroupActionButton(navigate, dispatch, props)}
+            <Button
+                variant='primary'
+                onClick={() => navigate('/admin/groups/create')}
+            >
+                Create Group
+            </Button>
+        </SpaceBetween>
+    );
+}
+
+function GroupActionButton (navigate: NavigateFunction, dispatch: Dispatch, props?: any) {
+    const selectedGroup: IGroup = props?.selectedItems[0];
+    const items = [];
+    if (selectedGroup) {
+        items.push({
+            text: 'Delete Group',
+            id: 'deleteGroup',
+        });
+        items.push({
+            text: 'Edit Group',
+            id: 'editGroup',
+        });
+    }
+
+    return (
+        <ButtonDropdown
+            items={items}
+            variant='primary'
+            disabled={!selectedGroup}
+            onItemClick={(e) => GroupActionHandler(e, selectedGroup, dispatch, navigate)}
+        >
+            Actions
+        </ButtonDropdown>
+    );
+}
+
+const GroupActionHandler = async (
+    e: any,
+    selectedGroup: IGroup,
+    dispatch: ThunkDispatch<any, any, Action>,
+    navigate: NavigateFunction
+) => {
+    switch (e.detail.id) {
+        case 'deleteGroup':
+            dispatch(
+                setDeleteModal({
+                    resourceName: 'Group',
+                    resourceType: 'group',
+                    onConfirm: async () => dispatch(deleteGroup(selectedGroup.name)),
+                    postConfirm: () => dispatch(getAllGroups()),
+                    description: `This will delete the following group: ${selectedGroup.name}.`
+                })
+            );
+            break;
+        case 'editGroup':
+            navigate(`/admin/groups/edit/${selectedGroup.name}`);
+            break;
+        default:
+            return;
+    }
+};
+
+export { GroupActions };

--- a/frontend/src/entities/group/group.columns.ts
+++ b/frontend/src/entities/group/group.columns.ts
@@ -1,0 +1,58 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { TableProps } from '@cloudscape-design/components';
+import { IGroup } from '../../shared/model/group.model';
+import { linkify } from '../../shared/util/table-utils';
+
+
+const groupColumns: TableProps.ColumnDefinition<IGroup>[] = [
+    {
+        id: 'name',
+        header: 'Name',
+        sortingField: 'name',
+        cell: (item) => (
+            linkify('group', item.name, undefined)
+        ),
+    },
+    {
+        id: 'description',
+        header: 'Description',
+        sortingField: 'description',
+        cell: (item) => item.description,
+    },
+];
+
+const visibleColumns: string[] = ['name', 'description'];
+
+const visibleContentPreference = {
+    title: 'Select visible group content',
+    options: [
+        {
+            label: 'Group properties',
+            options: [
+                {id: 'name', label: 'Name'},
+                {id: 'description', label: 'Description'},
+            ],
+        },
+    ],
+};
+
+export {
+    groupColumns,
+    visibleColumns,
+    visibleContentPreference
+};

--- a/frontend/src/entities/group/group.reducer.ts
+++ b/frontend/src/entities/group/group.reducer.ts
@@ -1,0 +1,82 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { createAsyncThunk, createSlice, isFulfilled, isPending } from '@reduxjs/toolkit';
+import axios from '../../shared/util/axios-utils';
+import { IGroup } from '../../shared/model/group.model';
+import { IGroupUser } from '../../shared/model/groupUser.model';
+
+const initialState = {
+    allGroups: [] as IGroup[],
+    loading: false,
+};
+
+
+export const getAllGroups = createAsyncThunk('group/fetch_all_groups', async () => {
+    return axios.get<IGroup[]>('/group');
+});
+
+export const getGroup = createAsyncThunk('group/fetch_group', async (groupName: string) => {
+    return axios.get<IGroup>(`/group/${groupName}`);
+});
+
+export const deleteGroup = createAsyncThunk('group/delete_group', async (groupName: string) => {
+    const requestUrl = `/group/${groupName}`;
+    return axios.delete(requestUrl);
+});
+
+export const createGroup = createAsyncThunk('group/create_group', async (group: IGroup) => {
+    return axios.post('/group', JSON.stringify(group));
+});
+
+export const updateGroup = createAsyncThunk('group/update_group', async (group: IGroup) => {
+    const requestUrl = `/group/${group.name}`;
+    return axios.put(requestUrl, JSON.stringify(group));
+});
+
+export const getGroupUsers = createAsyncThunk('group/group_users', async (groupName: string) => {
+    const requestUrl = `/group/${groupName}/users`;
+    return axios.get<IGroupUser[]>(requestUrl);
+});
+
+export const GroupSlice = createSlice({
+    name: 'group',
+    initialState,
+    extraReducers (builder) {
+        builder
+            .addMatcher(isFulfilled(getAllGroups), (state, action) => {
+                return {
+                    ...state,
+                    allGroups: action.payload.data,
+                    loading: false,
+                };
+            })
+            .addMatcher(isFulfilled(deleteGroup, createGroup, updateGroup, getGroup, getGroupUsers), (state) => {
+                return {
+                    ...state,
+                    loading: false,
+                };
+            })
+            .addMatcher(isPending(getAllGroups, deleteGroup, createGroup, updateGroup, getGroup, getGroupUsers), (state) => {
+                return {
+                    ...state,
+                    loading: true,
+                };
+            });
+    },
+});
+
+export default GroupSlice.reducer;

--- a/frontend/src/entities/group/group.reducer.ts
+++ b/frontend/src/entities/group/group.reducer.ts
@@ -64,13 +64,13 @@ export const GroupSlice = createSlice({
                     loading: false,
                 };
             })
-            .addMatcher(isFulfilled(deleteGroup, createGroup, updateGroup, getGroup, getGroupUsers), (state) => {
+            .addMatcher(isFulfilled(deleteGroup, createGroup, updateGroup), (state) => {
                 return {
                     ...state,
                     loading: false,
                 };
             })
-            .addMatcher(isPending(getAllGroups, deleteGroup, createGroup, updateGroup, getGroup, getGroupUsers), (state) => {
+            .addMatcher(isPending(getAllGroups, deleteGroup, createGroup, updateGroup), (state) => {
                 return {
                     ...state,
                     loading: true,

--- a/frontend/src/entities/group/group.tsx
+++ b/frontend/src/entities/group/group.tsx
@@ -1,0 +1,52 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import React, { useEffect } from 'react';
+import { groupColumns, visibleColumns } from './group.columns';
+import Table from '../../modules/table';
+import { IGroup } from '../../shared/model/group.model';
+import { useAppDispatch, useAppSelector } from '../../config/store';
+import { getAllGroups } from './group.reducer';
+import { DocTitle } from '../../shared/doc';
+import { GroupActions } from '../group/group.actions';
+
+export function Group () {
+    const groups: IGroup[] = useAppSelector((state) => state.group.allGroups);
+    const loadingGroups = useAppSelector((state) => state.group.loading);
+    const dispatch = useAppDispatch();
+    const actions = (e: any) => GroupActions({...e});
+    DocTitle('Groups');
+
+    useEffect(() => {
+        dispatch(getAllGroups());
+    }, [dispatch]);
+
+    return (
+        <Table
+            tableName='Group'
+            trackBy='name'
+            actions={actions}
+            allItems={groups}
+            tableType='single'
+            columnDefinitions={groupColumns}
+            visibleColumns={visibleColumns}
+            loadingItems={loadingGroups}
+            loadingText='Loading groups'
+        />
+    );
+}
+
+export default Group;

--- a/frontend/src/entities/group/index.ts
+++ b/frontend/src/entities/group/index.ts
@@ -1,0 +1,19 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Group from './group';
+
+export default Group;

--- a/frontend/src/entities/project/create/project-create.tsx
+++ b/frontend/src/entities/project/create/project-create.tsx
@@ -85,7 +85,7 @@ export function ProjectCreate ({ isEdit }: ResourceCreateProperties) {
             .max(4000, {
                 message: 'Project description cannot be more than 4000 characters.',
             })
-            .regex(/[ -~]/, {
+            .regex(/^[ -~]$/, {
                 message: 'Project description can only contain printable characters',
             }),
         emrRuntime: z

--- a/frontend/src/entities/project/create/project-create.tsx
+++ b/frontend/src/entities/project/create/project-create.tsx
@@ -85,7 +85,7 @@ export function ProjectCreate ({ isEdit }: ResourceCreateProperties) {
             .max(4000, {
                 message: 'Project description cannot be more than 4000 characters.',
             })
-            .regex(/^[ -~]$/, {
+            .regex(/^[ -~]+$/, {
                 message: 'Project description can only contain printable characters',
             }),
         emrRuntime: z

--- a/frontend/src/entities/reducers.ts
+++ b/frontend/src/entities/reducers.ts
@@ -15,6 +15,7 @@
 */
 
 import user from './user/user.reducer';
+import group from './group/group.reducer';
 import notebook from './notebook/notebook.reducer';
 import project from './project/project.reducer';
 import projectCard from './project/card/project-card.reducer';
@@ -31,6 +32,7 @@ import appConfig from './configuration/configuration-reducer';
 
 const entitiesReducers = {
     user,
+    group,
     notebook,
     project,
     projectCard,

--- a/frontend/src/entities/routes.tsx
+++ b/frontend/src/entities/routes.tsx
@@ -27,6 +27,7 @@ import Model from './model';
 import ModelCreate from './model/create';
 import ModelDetail from './model/detail';
 import User from './user';
+import Group from './group';
 import ProjectDetail from './project/detail';
 import ProjectCreate from './project/create';
 import ProjectUser from './project/users/project-user';
@@ -56,6 +57,8 @@ import BatchTranslateDetail from './batch-translate/detail';
 import TranslateRealtime from './translate-realtime/translate-realtime';
 import { appConfig } from './configuration/configuration-reducer';
 import { IAppConfiguration } from '../shared/model/app.configuration.model';
+import GroupCreate from './group/create';
+import GroupDetail from './group/detail';
 
 const EntityRoutes = () => {
     const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
@@ -67,6 +70,10 @@ const EntityRoutes = () => {
             <ErrorBoundaryRoutes>
                 <Route element={<RequireAdmin />}>
                     <Route path='admin/users' element={<User />} />
+                    <Route path='admin/groups' element={<Group />} />
+                    <Route path='admin/groups/create' element={<GroupCreate />} />
+                    <Route path='admin/groups/edit/:groupName' element={<GroupCreate isEdit={true} />} />
+                    <Route path='admin/groups/:groupName' element={<GroupDetail />} />
                     <Route path='admin/configuration' element={<Configuration />} />
                     <Route path='admin/reports' element={<Report />} />
                 </Route>

--- a/frontend/src/entities/user/user.columns.ts
+++ b/frontend/src/entities/user/user.columns.ts
@@ -17,6 +17,17 @@
 import { TableProps } from '@cloudscape-design/components';
 import { IProjectUser } from '../../shared/model/projectUser.model';
 import { IUser, Permission } from '../../shared/model/user.model';
+import { IGroupUser } from '../../shared/model/groupUser.model';
+
+const groupUserColumns: TableProps.ColumnDefinition<IGroupUser>[] = [
+    { id: 'name', header: 'Name', sortingField: 'name', cell: (item) => item.user },
+    {
+        id: 'co',
+        header: 'Collaborator',
+        sortingField: 'co',
+        cell: (item) => (item.permissions?.includes(Permission.COLLABORATOR) ? 'Yes' : 'No'),
+    },
+];
 
 const projectUserColumns: TableProps.ColumnDefinition<IProjectUser>[] = [
     { id: 'name', header: 'Name', sortingField: 'name', cell: (item) => item.user },
@@ -65,6 +76,7 @@ const userColumns: TableProps.ColumnDefinition<IUser>[] = [
 ];
 
 const visibleColumns: string[] = ['name', 'suspended', 'admin', 'lastLogin'];
+const visibleGroupUserColumns: string[] = ['name', 'co'];
 const visibleProjectUserColumns: string[] = ['name', 'mo', 'co'];
 
 const visibleContentPreference = {
@@ -84,6 +96,8 @@ const visibleContentPreference = {
 const addUserVisibleColumns: string[] = ['name', 'displayName', 'email'];
 
 export {
+    groupUserColumns,
+    visibleGroupUserColumns,
     projectUserColumns,
     userColumns,
     visibleColumns,

--- a/frontend/src/shared/layout/navigation/navigation.reducer.ts
+++ b/frontend/src/shared/layout/navigation/navigation.reducer.ts
@@ -48,6 +48,7 @@ const navigationSlice = createSlice({
                     defaultExpanded: true,
                     items: [
                         { type: 'link', text: 'Users', href: '#/admin/users' },
+                        { type: 'link', text: 'Groups', href: '#/admin/groups' },
                         { type: 'link', text: 'Configuration', href: '#/admin/configuration' },
                         { type: 'link', text: 'Reports', href: '#/admin/reports' },
                     ],

--- a/frontend/src/shared/model/group.model.ts
+++ b/frontend/src/shared/model/group.model.ts
@@ -1,0 +1,30 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+export type IGroup = {
+    name?: string;
+    description?: string;
+    isOwner?: boolean;
+    isCollaborator?: boolean;
+};
+
+
+export const defaultProject: IGroup = {
+    name: '',
+    description: '',
+};
+
+export const defaultValue: Readonly<IGroup> = defaultProject;

--- a/frontend/src/shared/model/group.model.ts
+++ b/frontend/src/shared/model/group.model.ts
@@ -22,7 +22,7 @@ export type IGroup = {
 };
 
 
-export const defaultProject: IGroup = {
+export const defaultGroup: IGroup = {
     name: '',
     description: '',
 };

--- a/frontend/src/shared/model/groupUser.model.ts
+++ b/frontend/src/shared/model/groupUser.model.ts
@@ -1,0 +1,26 @@
+/**
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import { Permission } from './user.model';
+
+export type IGroupUser = {
+    user?: string;
+    group?: string;
+    permissions?: Permission[];
+    role?: string;
+};
+
+export const defaultValue: Readonly<IGroupUser> = {};


### PR DESCRIPTION
Initial changes for CRUD on in app group management. 

User management in groups will come in a later PR, as will non-admin users being able to view what groups they are in.

![demo](https://github.com/awslabs/mlspace/assets/14100972/386a5111-2ff9-4552-843f-38493f3bd502)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
