### PR TITLE
users can get a read only view of the groups they are in

### DIFF
--- a/frontend/src/entities/group/detail/group-detail-user.actions.tsx
+++ b/frontend/src/entities/group/detail/group-detail-user.actions.tsx
@@ -24,7 +24,9 @@ import { ModalProps } from '../../../modules/modal';
 import { IGroupUser } from '../../../shared/model/groupUser.model';
 import NotificationService from '../../../shared/layout/notification/notification.service';
 import AddGroupUserModal from './add-group-user-modal';
-import { IUser } from '../../../shared/model/user.model';
+import { IUser, Permission } from '../../../shared/model/user.model';
+import { hasPermission } from '../../../shared/util/permission-utils';
+import { selectCurrentUser } from '../../user/user.reducer';
 
 function GroupDetailUserActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -35,6 +37,7 @@ function GroupDetailUserActions (props?: any) {
     const groupUsernames = groupUsers.map((user) => user.user);
     const addableUsers = allUsers.filter((user) => !groupUsernames.includes(user.username!));
     const [addUserModalVisible, setAddUserModalVisible] = useState(false);
+    const currentUser = useAppSelector(selectCurrentUser);
 
     return (
         <SpaceBetween direction='horizontal' size='xs'>
@@ -42,18 +45,12 @@ function GroupDetailUserActions (props?: any) {
             <Button onClick={() => dispatch(getGroupUsers(groupName))} ariaLabel={'Refresh groups list'}>
                 <Icon name='refresh'/>
             </Button>
-            {GroupDetailUserActionsButton(navigate, dispatch, props)}
-            <Button
-                variant='primary'
-                onClick={() => setAddUserModalVisible(true)}
-            >
-                Add User
-            </Button>
+            {GroupDetailUserActionsButton(navigate, dispatch, currentUser, setAddUserModalVisible, props)}
         </SpaceBetween>
     );
 }
 
-function GroupDetailUserActionsButton (navigate: NavigateFunction, dispatch: Dispatch, props?: any) {
+function GroupDetailUserActionsButton (navigate: NavigateFunction, dispatch: Dispatch, currentUser: IUser, setAddUserModalVisible: (boolean) => void, props?: any) {
     const selectedUser: IGroupUser = props?.selectedItems[0];
     const items: ButtonDropdownProps.Item[] = [];
     if (selectedUser) {
@@ -70,14 +67,25 @@ function GroupDetailUserActionsButton (navigate: NavigateFunction, dispatch: Dis
     });
 
     return (
-        <ButtonDropdown
-            items={items}
-            variant='primary'
-            disabled={!selectedUser}
-            onItemClick={(e) => GroupDetailUserActionHandler(e, dispatch, modalState as ModalProps, setModalState, selectedUser)}
-        >
-            Actions
-        </ButtonDropdown>
+        <> { hasPermission(Permission.ADMIN, currentUser.permissions) && (
+            <>
+                <ButtonDropdown
+                    items={items}
+                    variant='primary'
+                    disabled={!selectedUser}
+                    onItemClick={(e) => GroupDetailUserActionHandler(e, dispatch, modalState as ModalProps, setModalState, selectedUser)}
+                >
+                    Actions
+                </ButtonDropdown>
+                <Button
+                    variant='primary'
+                    onClick={() => setAddUserModalVisible(true)}
+                >
+                    Add User
+                </Button>
+            </>
+        )}
+        </>
     );
 }
 

--- a/frontend/src/entities/group/detail/group-detail.actions.tsx
+++ b/frontend/src/entities/group/detail/group-detail.actions.tsx
@@ -64,24 +64,27 @@ function GroupActionButton (
     }
 
     return (
-        <ButtonDropdown
-            items={actionItems}
-            variant='primary'
-            disabled={groupName === undefined}
-            onItemClick={(e) =>
-                GroupActionHandler(
-                    e,
-                    groupName,
-                    nav,
-                    dispatch,
-                    modalState as ModalProps,
-                    setModalState
-                )
-            }
-        >
-            <Modal {...(modalState as ModalProps)} />
-            Actions
-        </ButtonDropdown>
+        <> { hasPermission(Permission.ADMIN, currentUser.permissions) && (
+            <ButtonDropdown
+                items={actionItems}
+                variant='primary'
+                disabled={groupName === undefined}
+                onItemClick={(e) =>
+                    GroupActionHandler(
+                        e,
+                        groupName,
+                        nav,
+                        dispatch,
+                        modalState as ModalProps,
+                        setModalState
+                    )
+                }
+            >
+                <Modal {...(modalState as ModalProps)} />
+                Actions
+            </ButtonDropdown>
+        )}
+        </>
     );
 }
 

--- a/frontend/src/entities/group/detail/group-detail.tsx
+++ b/frontend/src/entities/group/detail/group-detail.tsx
@@ -28,6 +28,9 @@ import { groupUserColumns, visibleGroupUserColumns } from '../../user/user.colum
 import { IGroupUser } from '../../../shared/model/groupUser.model';
 import { GroupDetailUserActions } from './group-detail-user.actions';
 import { DocTitle } from '../../../shared/doc';
+import { selectCurrentUser } from '../../user/user.reducer';
+import { hasPermission } from '../../../shared/util/permission-utils';
+import { Permission } from '../../../shared/model/user.model';
 
 export function GroupDetail () {
     const dispatch = useAppDispatch();
@@ -36,6 +39,7 @@ export function GroupDetail () {
     const [group, setGroup] = useState<IGroup>(null);
     const groupUsers: IGroupUser[] = useAppSelector(currentGroupUsers);
     const loadingGroupUsers = useAppSelector((state) => state.group.loading);
+    const currentUser = useAppSelector(selectCurrentUser);
     const [initialLoaded, setInitialLoaded] = useState(false);
     const actions = (e: any) => GroupDetailUserActions({...e});
     DocTitle(`Group Details: ${groupName}`);
@@ -70,7 +74,7 @@ export function GroupDetail () {
                 />
                 <Table
                     tableName='Group member'
-                    tableType='single'
+                    tableType={hasPermission(Permission.ADMIN, currentUser.permissions) ? 'single' : undefined}
                     actions={actions}
                     itemNameProperty='user'
                     trackBy='user'

--- a/frontend/src/entities/group/group.actions.tsx
+++ b/frontend/src/entities/group/group.actions.tsx
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-import { useAppDispatch } from '../../config/store';
+import { useAppDispatch, useAppSelector } from '../../config/store';
 import { Button, ButtonDropdown, ButtonDropdownProps, Icon, SpaceBetween } from '@cloudscape-design/components';
 import { deleteGroup, getAllGroups } from './group.reducer';
 import React from 'react';
@@ -21,28 +21,26 @@ import { Action, Dispatch, ThunkDispatch } from '@reduxjs/toolkit';
 import { IGroup } from '../../shared/model/group.model';
 import { setDeleteModal } from '../../modules/modal/modal.reducer';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
+import { selectCurrentUser } from '../user/user.reducer';
+import { IUser, Permission } from '../../shared/model/user.model';
+import { hasPermission } from '../../shared/util/permission-utils';
 
 function GroupActions (props?: any) {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
+    const currentUser = useAppSelector(selectCurrentUser);
 
     return (
         <SpaceBetween direction='horizontal' size='xs'>
             <Button onClick={() => dispatch(getAllGroups())} ariaLabel={'Refresh groups list'}>
                 <Icon name='refresh'/>
             </Button>
-            {GroupActionButton(navigate, dispatch, props)}
-            <Button
-                variant='primary'
-                onClick={() => navigate('/admin/groups/create')}
-            >
-                Create Group
-            </Button>
+            {GroupActionButton(navigate, dispatch, currentUser, props)}
         </SpaceBetween>
     );
 }
 
-function GroupActionButton (navigate: NavigateFunction, dispatch: Dispatch, props?: any) {
+function GroupActionButton (navigate: NavigateFunction, dispatch: Dispatch, currentUser: IUser, props?: any) {
     const selectedGroup: IGroup = props?.selectedItems[0];
     const items: ButtonDropdownProps.Item[] = [];
     if (selectedGroup) {
@@ -57,14 +55,25 @@ function GroupActionButton (navigate: NavigateFunction, dispatch: Dispatch, prop
     }
 
     return (
-        <ButtonDropdown
-            items={items}
-            variant='primary'
-            disabled={!selectedGroup}
-            onItemClick={(e) => GroupActionHandler(e, selectedGroup, dispatch, navigate)}
-        >
-            Actions
-        </ButtonDropdown>
+        <> { hasPermission(Permission.ADMIN, currentUser.permissions) && (
+            <>
+                <ButtonDropdown
+                    items={items}
+                    variant='primary'
+                    disabled={!selectedGroup}
+                    onItemClick={(e) => GroupActionHandler(e, selectedGroup, dispatch, navigate)}
+                >
+                    Actions
+                </ButtonDropdown>
+                <Button
+                    variant='primary'
+                    onClick={() => navigate('/admin/groups/create')}
+                >
+                    Create Group
+                </Button>
+            </>
+        )}
+        </>
     );
 }
 

--- a/frontend/src/entities/group/group.tsx
+++ b/frontend/src/entities/group/group.tsx
@@ -21,13 +21,17 @@ import { IGroup } from '../../shared/model/group.model';
 import { useAppDispatch, useAppSelector } from '../../config/store';
 import { getAllGroups } from './group.reducer';
 import { DocTitle } from '../../shared/doc';
-import { GroupActions } from '../group/group.actions';
+import { GroupActions } from './group.actions';
+import { selectCurrentUser } from '../user/user.reducer';
+import { hasPermission } from '../../shared/util/permission-utils';
+import { Permission } from '../../shared/model/user.model';
 
 export function Group () {
     const groups: IGroup[] = useAppSelector((state) => state.group.allGroups);
     const loadingGroups = useAppSelector((state) => state.group.loading);
     const dispatch = useAppDispatch();
     const actions = (e: any) => GroupActions({...e});
+    const currentUser = useAppSelector(selectCurrentUser);
     DocTitle('Groups');
 
     useEffect(() => {
@@ -40,7 +44,7 @@ export function Group () {
             trackBy='name'
             actions={actions}
             allItems={groups}
-            tableType='single'
+            tableType={hasPermission(Permission.ADMIN, currentUser.permissions) ? 'single' : undefined}
             columnDefinitions={groupColumns}
             visibleColumns={visibleColumns}
             loadingItems={loadingGroups}

--- a/frontend/src/entities/routes.tsx
+++ b/frontend/src/entities/routes.tsx
@@ -77,6 +77,8 @@ const EntityRoutes = () => {
                     <Route path='admin/configuration' element={<Configuration />} />
                     <Route path='admin/reports' element={<Report />} />
                 </Route>
+                <Route path='personal/group' element={<Group />} />
+                <Route path='personal/group/:groupName' element={<GroupDetail />} />
                 <Route path='personal/dataset' element={<Dataset />} />
                 <Route path='personal/dataset/create' element={<DatasetCreate />} />
                 <Route path='personal/dataset/:scope/:name/edit' element={<DatasetUpdate />} />

--- a/frontend/src/shared/layout/navigation/side-navigation.tsx
+++ b/frontend/src/shared/layout/navigation/side-navigation.tsx
@@ -25,7 +25,7 @@ import {
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import {setActiveHref, setItemsForProjectName} from './navigation.reducer';
 import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
-import { IProject } from '../../model/project.model';
+import { IProject } from '../../model';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { colorTextBodyDefault } from '@cloudscape-design/design-tokens';
 import Logo from '../logo/logo';
@@ -72,6 +72,7 @@ export default function SideNavigation () {
 
     const personalNavItems: SideNavigationProps.Item[] = [
         { type: 'link', text: 'Projects', href: '#/' },
+        { type: 'link', text: 'Groups', href: '#/personal/group' },
         { type: 'link', text: 'Notebook instances', href: '#/personal/notebook' },
         { type: 'link', text: 'Datasets', href: '#/personal/dataset' },
     ];


### PR DESCRIPTION
Adding a readonly view for users so they can get the group details for groups they are members of.

![demo](https://github.com/awslabs/mlspace/assets/14100972/522119ae-d879-40dc-8088-6915c087db30)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
