### PR TITLE
Added useNotificationService() hook

### DIFF
--- a/frontend/src/entities/batch-translate/batch-translate.actions.tsx
+++ b/frontend/src/entities/batch-translate/batch-translate.actions.tsx
@@ -20,8 +20,8 @@ import { Action, Dispatch, ThunkDispatch } from '@reduxjs/toolkit';
 import { Button, ButtonDropdown, SpaceBetween } from '@cloudscape-design/components';
 import { stopBatchTranslateJob } from './batch-translate.reducer';
 import { useAppDispatch } from '../../config/store';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { BatchTranslateResourceMetadata } from '../../shared/model/resource-metadata.model';
+import { useNotificationService } from '../../shared/util/hooks';
 
 function BatchTranslateActions (props?: any) {
     const navigate = useNavigate();
@@ -86,7 +86,7 @@ const BatchTranslateActionHandler = async (
     dispatch: ThunkDispatch<any, any, Action>,
     projectName: string
 ) => {
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     let response: any | undefined = undefined;
     switch (e.detail.id) {
         case 'details':

--- a/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
+++ b/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
@@ -33,7 +33,6 @@ import { useAppDispatch } from '../../../config/store';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
 import { createBatchTranslateJob } from '../batch-translate.reducer';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { issuesToErrors, scrollToInvalid, useValidationReducer } from '../../../shared/validation';
 import { z } from 'zod';
 import { DocTitle, scrollToPageHeader } from '../../../shared/doc';
@@ -57,6 +56,7 @@ import { datasetFromS3Uri } from '../../../shared/util/dataset-utils';
 import { isFulfilled } from '@reduxjs/toolkit';
 import { AUTO_SOURCE_LANGUAGE_UNSUPPORTED } from '..';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 export function BatchTranslateCreate () {
     const [errorText] = useState('');
@@ -66,7 +66,7 @@ export function BatchTranslateCreate () {
     const autoOption: SelectProps.Option = { label: 'Auto (auto)', value: 'auto' };
     const { projectName } = useParams();
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const navigate = useNavigate();
     const auth = useAuth();
     const userName = auth.user!.profile.preferred_username;

--- a/frontend/src/entities/batch-translate/detail/batch-translate-detail.tsx
+++ b/frontend/src/entities/batch-translate/detail/batch-translate-detail.tsx
@@ -36,10 +36,9 @@ import {
     selectedBatchTranslateJob,
     stopBatchTranslateJob,
 } from '../batch-translate.reducer';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { getDownloadUrl } from '../../dataset/dataset.service';
-import { useBackgroundRefresh } from '../../../shared/util/hooks';
+import { useBackgroundRefresh, useNotificationService } from '../../../shared/util/hooks';
 import ContentLayout from '../../../shared/layout/content-layout';
 
 function BatchTranslateDetail () {
@@ -47,7 +46,7 @@ function BatchTranslateDetail () {
     const dispatch = useAppDispatch();
     const batchTranslateJob: IBatchTranslate = useAppSelector(selectedBatchTranslateJob);
     const jobLoading = useAppSelector(loadingBatchTranslateJob);
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     const [initialLoaded, setInitialLoaded] = useState(false);
 

--- a/frontend/src/entities/configuration/configuration-history-table.tsx
+++ b/frontend/src/entities/configuration/configuration-history-table.tsx
@@ -20,14 +20,14 @@ import { IAppConfiguration, defaultConfiguration } from '../../shared/model/app.
 import { appConfig, appConfigList, getConfiguration, listConfigurations, loadingAppConfigList, updateConfiguration } from './configuration-reducer';
 import { Box, Button, FormField, Header, Input, Modal, SpaceBetween } from '@cloudscape-design/components';
 import Table from '../../modules/table';
-import NotificationService from '../../shared/layout/notification/notification.service';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export function ConfigurationHistoryTable () {
     const configList: IAppConfiguration[] = useAppSelector(appConfigList);
     const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     const loadingConfigList: boolean = useAppSelector(loadingAppConfigList);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const [modal, setModal] = React.useState<{ visible: boolean; prevConfig: IAppConfiguration, newConfig: IAppConfiguration }>({
         visible: false,
         prevConfig: defaultConfiguration,

--- a/frontend/src/entities/configuration/deployment-configuration.tsx
+++ b/frontend/src/entities/configuration/deployment-configuration.tsx
@@ -33,7 +33,7 @@ import { getEnvironmentConfig } from './configuration.service';
 import { getBase } from '../../shared/util/breadcrumb-utils';
 import { useParams } from 'react-router-dom';
 import axios from '../../shared/util/axios-utils';
-import NotificationService from '../../shared/layout/notification/notification.service';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export function DeploymentConfiguration () {
     const [config, setEnvConfig] = useState(defaultEnvConfig);
@@ -41,7 +41,7 @@ export function DeploymentConfiguration () {
     const dispatch = useAppDispatch();
     const { projectName } = useParams();
     const [syncingMetadata, setSyncingMetadata] = useState(false);
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     const generateDescription = (service: string) => {
         return `Sync metadata for all ${service} associated with ${window.env.APPLICATION_NAME}`;

--- a/frontend/src/entities/configuration/dynamic-configuration.tsx
+++ b/frontend/src/entities/configuration/dynamic-configuration.tsx
@@ -25,7 +25,6 @@ import {
 import React, { useEffect, useState } from 'react';
 import { z } from 'zod';
 import { useAppDispatch, useAppSelector } from '../../config/store';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { IAppConfiguration } from '../../shared/model/app.configuration.model';
 import { scrollToInvalid, useValidationReducer } from '../../shared/validation';
 import { listEMRApplications } from '../emr/emr.reducer';
@@ -37,11 +36,12 @@ import ConfirmConfigurationChangesModal from './confirm-configuration-changes-mo
 import EmrConfiguration from './emr-configuration';
 import ProjectCreationConfiguration from './project-creation-configuration';
 import SystemBannerConfiguration from './system-banner-configuration';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export function DynamicConfiguration () {
     const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const [importConfigVisible, setImportConfigVisible] = useState(false);
     const [selectedFile, setSelectedFile] = useState<File[]>([]);
     const [modalVisible, setModalVisible] = useState(false);

--- a/frontend/src/entities/dataset/create/dataset-create.tsx
+++ b/frontend/src/entities/dataset/create/dataset-create.tsx
@@ -49,9 +49,9 @@ import DatasetBrowser from '../../../modules/dataset/dataset-browser';
 import { DatasetBrowserActions } from '../dataset.actions';
 import { DatasetBrowserManageMode } from '../../../modules/dataset/dataset-browser.types';
 import { DatasetResourceObject } from '../../../modules/dataset/dataset-browser.reducer';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { useUsername } from '../../../shared/util/auth-utils';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 const formSchema = z.object({
     name: z
@@ -82,7 +82,7 @@ export function DatasetCreate () {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const basePath = projectName ? `/project/${projectName}` : '/personal';
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     const { state, setState, errors, isValid, touchFields, setFields } = useValidationReducer(formSchema, {
         validateAll: false,

--- a/frontend/src/entities/dataset/dataset-drag-and-drop.tsx
+++ b/frontend/src/entities/dataset/dataset-drag-and-drop.tsx
@@ -17,13 +17,13 @@
 import React, { useRef } from 'react';
 import { useEffect } from 'react';
 import { useAppDispatch } from '../../config/store';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { fileHandler } from './dataset.actions';
+import { useNotificationService } from '../../shared/util/hooks';
 
 
 export const FullScreenDragAndDrop = ({state, setState, updateDatasetContext, setDisableUpload}): React.ReactNode => {
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const dropzone = useRef<HTMLDivElement>(null);
     const {manageMode} = state;
 

--- a/frontend/src/entities/dataset/dataset.actions.tsx
+++ b/frontend/src/entities/dataset/dataset.actions.tsx
@@ -29,7 +29,6 @@ import { useAppDispatch, useAppSelector } from '../../config/store';
 import { copyButtonAriaLabel, deleteButtonAriaLabel, downloadButtonAriaLabel } from './dataset.utils';
 import Condition from '../../modules/condition';
 import { determineScope, getDownloadUrl, uploadResources } from './dataset.service';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { setDeleteModal } from '../../modules/modal/modal.reducer';
 import { deletionDescription } from '../../shared/util/form-utils';
 import { selectCurrentUser } from '../user/user.reducer';
@@ -44,6 +43,7 @@ import { Dispatch as ReactDispatch } from 'react';
 import { DatasetContext } from '../../shared/util/dataset-utils';
 import './dataset.scss';
 import { FullScreenDragAndDrop } from './dataset-drag-and-drop';
+import { useNotificationService } from '../../shared/util/hooks';
 
 function DatasetActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -115,7 +115,7 @@ type UploadButtonProperties = {
 
 const UploadButton = ({state, setState, updateDatasetContext, isFileUpload, disableUpload, setDisableUpload, children}: UploadButtonProperties): React.ReactNode => {
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const {manageMode} = state;
     const uploadFile: RefObject<HTMLInputElement> = useRef(null);
 

--- a/frontend/src/entities/dataset/update/dataset-update.tsx
+++ b/frontend/src/entities/dataset/update/dataset-update.tsx
@@ -37,12 +37,12 @@ import {
     datasetBinding,
     loadingDataset,
 } from '../dataset.reducer';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { z } from 'zod';
 import { scrollToInvalid, useValidationState } from '../../../shared/validation';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { selectCurrentUser } from '../../user/user.reducer';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 const formSchema = z.object({
     description: z.string().regex(/^[\w\-\s']+$/, {
@@ -57,7 +57,7 @@ export function DatasetUpdate () {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const basePath = projectName ? `/project/${projectName}` : '/personal';
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const loadingDatasetEditPage = useAppSelector(loadingDataset);
 
     scrollToPageHeader();

--- a/frontend/src/entities/emr/create/emr-cluster-create.tsx
+++ b/frontend/src/entities/emr/create/emr-cluster-create.tsx
@@ -30,7 +30,6 @@ import {
 import { useNavigate, useParams } from 'react-router-dom';
 import z from 'zod';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { issuesToErrors, scrollToInvalid, useValidationReducer } from '../../../shared/validation';
 import { createEMRCluster, emrReleaseLabels, listEMRReleaseLabels } from '../emr.reducer';
 import { setBreadcrumbs } from '../../../../src/shared/layout/navigation/navigation.reducer';
@@ -46,6 +45,7 @@ import { LoadingStatus } from '../../../shared/loading-status';
 import { ClusterType, IAppConfiguration } from '../../../shared/model/app.configuration.model';
 import { appConfig } from '../../configuration/configuration-reducer';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 enum ClusterAmi {
     BUILT_IN = 'built-in',
@@ -57,7 +57,7 @@ export default function EMRClusterCreate () {
     const { projectName } = useParams();
     const basePath = `/project/${projectName}/emr`;
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const subnets = useAppSelector(selectSubnets);
     const applicationConfig: IAppConfiguration = useAppSelector(appConfig);
     const releaseLabels: string[] = useAppSelector(emrReleaseLabels);

--- a/frontend/src/entities/endpoint-config/create/endpoint-config-create.tsx
+++ b/frontend/src/entities/endpoint-config/create/endpoint-config-create.tsx
@@ -40,7 +40,6 @@ import {
 } from '../endpoint-config.reducer';
 import { AddModelModal, EditVariantModal } from './modals';
 import { ConditionalWrapper } from '../../../modules/condition/condition';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { getEndpointConfigByName } from '../endpoint-config.service';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { scrollToInvalid, useValidationState } from '../../../shared/validation';
@@ -49,6 +48,7 @@ import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { setTableAnnouncement } from '../../../shared/util/table-utils';
 import { generateNameConstraintText } from '../../../shared/util/form-utils';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 type EndpointConfigCreateOptions = {
     createConfigCallback?: (endpointConfig: IEndpointConfig, createdNew: boolean) => void;
@@ -61,7 +61,7 @@ export function EndpointConfigCreate ({ createConfigCallback }: EndpointConfigCr
     const { projectName } = useParams();
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     if (!createConfigCallback) {
         DocTitle('Create Endpoint Config');

--- a/frontend/src/entities/endpoint-config/endpoint-config.tsx
+++ b/frontend/src/entities/endpoint-config/endpoint-config.tsx
@@ -31,12 +31,12 @@ import { useParams } from 'react-router-dom';
 import { EmbeddedableComponent } from './common-components';
 import { Box, Button } from '@cloudscape-design/components';
 import { CallbackFunction } from '../../types';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { getEndpointConfigByName } from './endpoint-config.service';
 import { getBase } from '../../shared/util/breadcrumb-utils';
 import { DocTitle, scrollToPageHeader } from '../../../src/shared/doc';
 import { focusOnCreateButton } from '../../shared/util/url-utils';
 import { EndpointConfigResourceMetadata } from '../../shared/model/resource-metadata.model';
+import { useNotificationService } from '../../shared/util/hooks';
 
 type EndpointConfigComponentOptions = {
     selectEndpointConfig?: CallbackFunction;
@@ -55,7 +55,7 @@ export const EndpointConfig = ({
     const { projectName } = useParams();
 
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     if (isEmbedded === false) {
         DocTitle(projectName!.concat(' Endpoint Configs'));

--- a/frontend/src/entities/endpoint/create/endpoint-create.tsx
+++ b/frontend/src/entities/endpoint/create/endpoint-create.tsx
@@ -36,12 +36,12 @@ import EndpointConfigCreate from '../../endpoint-config/create';
 import { IEndpointConfig } from '../../../shared/model/endpoint-config.model';
 import { NewEndpointConfigDetails } from './new-config-details';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { scrollToInvalid, useValidationState } from '../../../shared/validation';
 import { z } from 'zod';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { generateNameConstraintText } from '../../../shared/util/form-utils';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 export function EndpointCreate () {
     const [endpoint, setEndpoint] = useState(defaultEndpoint as IEndpoint);
@@ -52,7 +52,7 @@ export function EndpointCreate () {
     const [endpointConfigType, setEndpointConfigType] = useState('existing');
     const { projectName } = useParams();
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const navigate = useNavigate();
 
     scrollToPageHeader();

--- a/frontend/src/entities/jobs/hpo/create/hpo-job-create.tsx
+++ b/frontend/src/entities/jobs/hpo/create/hpo-job-create.tsx
@@ -40,13 +40,13 @@ import { ConfigureTuningJobResources } from './configure-tuning-job-resources';
 import { EditTrainingJobDefinition } from './edit-training-job-definition';
 import { useAuth } from 'react-oidc-context';
 import { getBase } from '../../../../shared/util/breadcrumb-utils';
-import NotificationService from '../../../../shared/layout/notification/notification.service';
 import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
 import { getDate, getPaddedNumberString } from '../../../../shared/util/date-utils';
 import { ML_ALGORITHMS } from '../../algorithms';
 import { getImageName } from './training-definitions/algorithm-options';
 import { tryCreateDataset } from '../../../dataset/dataset.service';
 import { datasetFromS3Uri } from '../../../../shared/util/dataset-utils';
+import { useNotificationService } from '../../../../shared/util/hooks';
 
 export type HPOJobCreateState = {
     editingJobDefinition: any;
@@ -64,7 +64,7 @@ export function HPOJobCreate () {
     const auth = useAuth();
     const userName = auth.user!.profile.preferred_username;
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     DocTitle('Create HPO Jobs');
 

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/training-job-definition.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/training-job-definition.tsx
@@ -39,9 +39,9 @@ import { HyperParameters } from './hyperparameters';
 import _ from 'lodash';
 import z from 'zod';
 import { ML_ALGORITHMS } from '../../../algorithms';
-import NotificationService from '../../../../../shared/layout/notification/notification.service';
 import { useAppDispatch } from '../../../../../config/store';
 import '../../../../../shared/validation/helpers/uri';
+import { useNotificationService } from '../../../../../shared/util/hooks';
 
 export type TrainingJobDefinitionProps = FormProps<ITrainingJobDefinition> & {
     onSubmit(): void;
@@ -116,7 +116,7 @@ export function TrainingJobDefinition (props: TrainingJobDefinitionProps) {
             : AlgorithmSource.CUSTOM
     );
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     const [state, setState] = React.useReducer(
         (state: any, action: { type: string; payload: any }) => {

--- a/frontend/src/entities/jobs/hpo/detail/hpo-job-detail.tsx
+++ b/frontend/src/entities/jobs/hpo/detail/hpo-job-detail.tsx
@@ -44,8 +44,7 @@ import { describeTrainingJob } from '../../training/training-job.reducer';
 import { prettyStatus } from '../../../../shared/util/table-utils';
 import { getBase } from '../../../../shared/util/breadcrumb-utils';
 import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
-import NotificationService from '../../../../shared/layout/notification/notification.service';
-import { useBackgroundRefresh } from '../../../../shared/util/hooks';
+import { useBackgroundRefresh, useNotificationService } from '../../../../shared/util/hooks';
 import ContentLayout from '../../../../shared/layout/content-layout';
 
 export function HPOJobDetail () {
@@ -53,7 +52,7 @@ export function HPOJobDetail () {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const HPOJobDetailsLoading = useAppSelector(loadingHPOJob);
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const [initialLoaded, setInitialLoaded] = useState(false);
 
     scrollToPageHeader();

--- a/frontend/src/entities/jobs/labeling/create/labeling-job-create.tsx
+++ b/frontend/src/entities/jobs/labeling/create/labeling-job-create.tsx
@@ -35,9 +35,9 @@ import {
 import { createLabelingJobThunk, listLabelingWorkTeams } from '../labeling-job.reducer';
 import _ from 'lodash';
 import { TASK_TYPE_CONFIG } from './labeling-job-task-config';
-import NotificationService from '../../../../shared/layout/notification/notification.service';
 import { LabelingJobTypes } from '../labeling-job.common';
 import '../../../../shared/validation/helpers/uri';
+import { useNotificationService } from '../../../../shared/util/hooks';
 
 export type ILabelingJobLabel = {
     label: string;
@@ -80,7 +80,7 @@ export function LabelingJobCreate () {
 
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     scrollToPageHeader();
     DocTitle('Labeling Job Create');

--- a/frontend/src/entities/jobs/training/create/training-job-create.tsx
+++ b/frontend/src/entities/jobs/training/create/training-job-create.tsx
@@ -57,7 +57,6 @@ import {
     getPaddedNumberString,
 } from '../../../../shared/util/date-utils';
 import { createTrainingJob as createTrainingJobThunk } from '../training-job.reducer';
-import NotificationService from '../../../../shared/layout/notification/notification.service';
 import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
 import { setBreadcrumbs } from '../../../../shared/layout/navigation/navigation.reducer';
 import { getBase } from '../../../../shared/util/breadcrumb-utils';
@@ -77,6 +76,7 @@ import '../../../../shared/validation/helpers/uri';
 import { datasetFromS3Uri } from '../../../../shared/util/dataset-utils';
 import { ServiceTypes } from '../../../../shared/model/app.configuration.model';
 import ContentLayout from '../../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../../shared/util/hooks';
 
 const ALGORITHMS: { [key: string]: Algorithm } = {};
 ML_ALGORITHMS.filter((algorithm) => algorithm.defaultHyperParameters.length > 0).map(
@@ -87,7 +87,7 @@ export default function TrainingJobCreate () {
     const { projectName } = useParams();
     const userName = useUsername();
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const navigate = useNavigate();
     const location = useLocation();
     const [algorithmSource, setAlgorithmSource] = useState(AlgorithmSource.BUILT_IN);

--- a/frontend/src/entities/jobs/transform/create/transform-create.tsx
+++ b/frontend/src/entities/jobs/transform/create/transform-create.tsx
@@ -32,7 +32,6 @@ import {
 import { AssembleWith, BatchStrategy, CompressionType, ITransform, S3DataType, SplitType, defaultValue } from '../../../../shared/model/transform.model';
 import { useAppDispatch, useAppSelector } from '../../../../config/store';
 import { setBreadcrumbs } from '../../../../shared/layout/navigation/navigation.reducer';
-import NotificationService from '../../../../shared/layout/notification/notification.service';
 import { createBatchTransformJob } from '../transform.reducer';
 import { z } from 'zod';
 import { getBase } from '../../../../shared/util/breadcrumb-utils';
@@ -64,6 +63,7 @@ import { DatasetResourceSelectorSelectableItems } from '../../../../modules/data
 import { ServiceTypes } from '../../../../shared/model/app.configuration.model';
 import ContentLayout from '../../../../shared/layout/content-layout';
 import { generateNameConstraintText } from '../../../../shared/util/form-utils';
+import { useNotificationService } from '../../../../shared/util/hooks';
 
 export function TransformCreate () {
     const [s3DataTypes, setS3DataTypes] = useState([] as SelectProps.Option[]);
@@ -80,7 +80,7 @@ export function TransformCreate () {
 
     const { projectName } = useParams();
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const navigate = useNavigate();
     const basePath = projectName ? `/project/${projectName}` : '/personal';
 

--- a/frontend/src/entities/jobs/transform/detail/transform-detail.tsx
+++ b/frontend/src/entities/jobs/transform/detail/transform-detail.tsx
@@ -34,13 +34,12 @@ import { ITransform } from '../../../../shared/model/transform.model';
 import { formatDate } from '../../../../shared/util/date-utils';
 import { formatDisplayText } from '../../../../shared/util/form-utils';
 import { JobStatus } from '../../job.model';
-import NotificationService from '../../../../shared/layout/notification/notification.service';
 import { prettyStatus } from '../../../../shared/util/table-utils';
 import { getBase } from '../../../../shared/util/breadcrumb-utils';
 import { DocTitle, scrollToPageHeader } from '../../../../../src/shared/doc';
 import DetailsContainer from '../../../../modules/details-container';
 import { LogsComponent } from '../../../../shared/util/log-utils';
-import { useBackgroundRefresh } from '../../../../shared/util/hooks';
+import { useBackgroundRefresh, useNotificationService } from '../../../../shared/util/hooks';
 import ContentLayout from '../../../../shared/layout/content-layout';
 
 function TransformDetail () {
@@ -52,7 +51,7 @@ function TransformDetail () {
 
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const basePath = projectName ? `#/project/${projectName}` : '#/personal';
 
     scrollToPageHeader();

--- a/frontend/src/entities/jobs/transform/transform.actions.tsx
+++ b/frontend/src/entities/jobs/transform/transform.actions.tsx
@@ -20,8 +20,8 @@ import { NavigateFunction, useNavigate, useParams } from 'react-router-dom';
 import { stopTransformJob } from './transform.service';
 import { Action, ThunkDispatch } from '@reduxjs/toolkit';
 import { useAppDispatch } from '../../../config/store';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { TransformJobResourceMetadata } from '../../../shared/model/resource-metadata.model';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 function BatchTransformJobActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -83,7 +83,7 @@ const BatchTransformJobActionHandler = (
     dispatch: ThunkDispatch<any, any, Action>,
     navigate: NavigateFunction
 ) => {
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     switch (e.detail.id) {
         case 'stop':
             stopTransformJob({ jobName: transform.resourceId, projectName: projectName }).then(

--- a/frontend/src/entities/model/create/model-create.tsx
+++ b/frontend/src/entities/model/create/model-create.tsx
@@ -38,7 +38,6 @@ import {
 } from '../../../shared/validation';
 import { defaultModel } from '../../../shared/model/model.model';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
 import { IModelContainerMode } from '../../../shared/model/container.model';
 import { AttributeEditorSchema } from '../../../modules/environment-variables/environment-variables';
@@ -46,10 +45,11 @@ import { NetworkSettings } from '../../jobs/hpo/create/training-definitions/netw
 import { generateNameConstraintText } from '../../../shared/util/form-utils';
 import '../../../shared/validation/helpers/uri';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 export function ModelCreate () {
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const navigate = useNavigate();
     const { projectName } = useParams();
     const currentLocation = useLocation();

--- a/frontend/src/entities/notebook/create/notebook-create.tsx
+++ b/frontend/src/entities/notebook/create/notebook-create.tsx
@@ -38,7 +38,6 @@ import {
     updateNotebookInstance,
 } from '../notebook.reducer';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { z } from 'zod';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { issuesToErrors, scrollToInvalid, useValidationReducer } from '../../../shared/validation';
@@ -67,6 +66,7 @@ import { convertDailyStopTime, timezoneDisplayString } from '../../../shared/uti
 import { EMRResourceMetadata } from '../../../shared/model/resource-metadata.model';
 import { ServiceTypes } from '../../../shared/model/app.configuration.model';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 export type NotebookCreateProps = {
     update?: boolean;
@@ -88,7 +88,7 @@ export function NotebookCreate ({ update }: NotebookCreateProps) {
     const loadingEMRClusters: boolean = useAppSelector(loadingClustersList);
     const [selectedCluster, setSelectedCluster] = useState({} as EMRResourceMetadata);
 
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     const { projectName, name } = useParams();
 

--- a/frontend/src/entities/notebook/detail/notebook-detail.tsx
+++ b/frontend/src/entities/notebook/detail/notebook-detail.tsx
@@ -32,7 +32,6 @@ import { prettyStatus } from '../../../shared/util/table-utils';
 import DetailsContainer from '../../../modules/details-container';
 import { formatDate, formatTerminationTimestamp } from '../../../shared/util/date-utils';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { setDeleteModal, setResourceScheduleModal } from '../../../modules/modal/modal.reducer';
 import { getNotebookInstanceUrl, notebookCluster } from '../notebook.service';
 import { DocTitle, scrollToPageHeader } from '../../../../src/shared/doc';
@@ -44,7 +43,7 @@ import { getProject } from '../../project/project.reducer';
 import { selectCurrentUser } from '../../user/user.reducer';
 import { hasPermission, isAdminOrProjectOwner } from '../../../shared/util/permission-utils';
 import { deletionDescription } from '../../../shared/util/form-utils';
-import { useBackgroundRefresh } from '../../../shared/util/hooks';
+import { useBackgroundRefresh, useNotificationService } from '../../../shared/util/hooks';
 import ContentLayout from '../../../shared/layout/content-layout';
 
 function NotebookDetail () {
@@ -60,7 +59,7 @@ function NotebookDetail () {
     const [initialLoaded, setInitialLoaded] = useState(false);
 
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const navigate = useNavigate();
     const basePath = projectName ? `/project/${projectName}` : '/personal';
 

--- a/frontend/src/entities/notebook/notebook.actions.tsx
+++ b/frontend/src/entities/notebook/notebook.actions.tsx
@@ -24,13 +24,13 @@ import {
 import { Button, ButtonDropdown, SpaceBetween } from '@cloudscape-design/components';
 import { useAppDispatch, useAppSelector } from '../../config/store';
 import { Action, Dispatch, ThunkDispatch, isFulfilled } from '@reduxjs/toolkit';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { setDeleteModal } from '../../modules/modal/modal.reducer';
 import { openNotebookInstance } from './notebook.service';
 import { selectCurrentUser } from '../user/user.reducer';
 import { NotebookResourceMetadata } from '../../shared/model/resource-metadata.model';
 import { isAdminOrProjectOwner } from '../../shared/util/permission-utils';
 import { deletionDescription } from '../../shared/util/form-utils';
+import { useNotificationService } from '../../shared/util/hooks';
 
 function NotebookActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -146,7 +146,7 @@ const NotebookActionHandler = async (
     projectName?: string
 ) => {
     const basePath = projectName ? `/project/${projectName}` : '/personal';
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     let response: any | undefined = undefined;
     switch (e.detail.id) {

--- a/frontend/src/entities/project/create/project-create.tsx
+++ b/frontend/src/entities/project/create/project-create.tsx
@@ -33,7 +33,6 @@ import {
 } from '@cloudscape-design/components';
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { scrollToInvalid, useValidationState } from '../../../shared/validation';
 import { selectProject } from '../card/project-card.reducer';
 import { createProject, getProject, listProjectsForUser, updateProject } from '../project.reducer';
@@ -48,6 +47,7 @@ import {
 import { selectCurrentUser } from '../../user/user.reducer';
 import { Timezone } from '../../../shared/model/user.model';
 import ContentLayout from '../../../shared/layout/content-layout';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 export type ResourceCreateProperties = {
     isEdit?: boolean;
@@ -56,7 +56,7 @@ export type ResourceCreateProperties = {
 export function ProjectCreate ({ isEdit }: ResourceCreateProperties) {
     const [submitLoading, setSubmitLoading] = React.useState(false);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const { projectName } = useParams();
     const navigate = useNavigate();
     const currentUser = useAppSelector(selectCurrentUser);

--- a/frontend/src/entities/project/detail/project-detail.actions.tsx
+++ b/frontend/src/entities/project/detail/project-detail.actions.tsx
@@ -26,8 +26,8 @@ import { deleteProject, getProject, listProjectsForUser, updateProject } from '.
 import { useAuth } from 'react-oidc-context';
 import { hasPermission } from '../../../shared/util/permission-utils';
 import { Permission } from '../../../shared/model/user.model';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import Modal, { ModalProps } from '../../../modules/modal';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 function ProjectDetailActions () {
     const dispatch = useAppDispatch();
@@ -123,7 +123,7 @@ const ProjectActionHandler = (
     modalState: ModalProps,
     setModalState: (state: Partial<ModalProps>) => void
 ) => {
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     switch (e.detail.id) {
         case 'update':

--- a/frontend/src/entities/project/users/project-user.tsx
+++ b/frontend/src/entities/project/users/project-user.tsx
@@ -33,7 +33,7 @@ import { IProjectUser } from '../../../shared/model/projectUser.model';
 import { useParams } from 'react-router-dom';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { DocTitle } from '../../../../src/shared/doc';
-import NotificationService from '../../../shared/layout/notification/notification.service';
+import { useNotificationService } from '../../../shared/util/hooks';
 
 export function ProjectUser () {
     const { projectName } = useParams();
@@ -47,7 +47,7 @@ export function ProjectUser () {
     const addableUsers = allUsers.filter((user) => !projectUsernames.includes(user.username!));
 
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     DocTitle(projectName!.concat(' Project Members'));
 

--- a/frontend/src/entities/project/users/project.user.actions.tsx
+++ b/frontend/src/entities/project/users/project.user.actions.tsx
@@ -35,9 +35,10 @@ import {
 import { IUser, Permission } from '../../../shared/model/user.model';
 import { IProjectUser } from '../../../shared/model/projectUser.model';
 import { isAdminOrProjectOwner, togglePermission } from '../../../shared/util/permission-utils';
-import NotificationService from '../../../shared/layout/notification/notification.service';
 import { useParams } from 'react-router-dom';
 import { setUpdateModal } from '../../../modules/modal/modal.reducer';
+import { useNotificationService } from '../../../shared/util/hooks';
+import NotificationService from '../../../shared/layout/notification/notification.service';
 
 function ProjectUserActions (props?: any) {
     const projectName = props?.projectName;
@@ -113,9 +114,9 @@ function ProjectUserActionButton (dispatch: Dispatch, props?: any) {
 async function addProjectUsers (
     projectName: string,
     users: IUser[],
+    notificationService: ReturnType<typeof NotificationService>,
     dispatch: ThunkDispatch<any, any, Action>
 ) {
-    const notificationService = NotificationService(dispatch);
     const response = await dispatch(
         addUsersToProject({
             usernames: users.map((user) => user.username!),
@@ -134,6 +135,7 @@ async function addProjectUsers (
 function AddProjectUserActionButton (dispatch: Dispatch, props?: any) {
     const { projectName } = useParams();
     const selectedUsers: IUser[] = props?.selectedItems;
+    const notificationService = useNotificationService(dispatch);
 
     const items = [{ text: 'Add to Project', id: 'add_member' }];
 
@@ -142,7 +144,7 @@ function AddProjectUserActionButton (dispatch: Dispatch, props?: any) {
             items={items}
             variant='primary'
             disabled={!selectedUsers}
-            onItemClick={() => addProjectUsers(projectName!, selectedUsers, dispatch)}
+            onItemClick={() => addProjectUsers(projectName!, selectedUsers, notificationService, dispatch)}
         >
             Actions
         </ButtonDropdown>

--- a/frontend/src/entities/report/report.actions.tsx
+++ b/frontend/src/entities/report/report.actions.tsx
@@ -15,15 +15,15 @@
 */
 
 import { deleteReport } from './report.service';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { Action, ThunkDispatch } from '@reduxjs/toolkit';
+import { useNotificationService } from '../../shared/util/hooks';
 
 function ReportActionHandler (
     e: any,
     reportName: string,
     dispatch: ThunkDispatch<any, any, Action>
 ) {
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     switch (e.detail.id) {
         case 'deleteReport':

--- a/frontend/src/entities/report/report.tsx
+++ b/frontend/src/entities/report/report.tsx
@@ -35,7 +35,6 @@ import { useAppDispatch } from '../../config/store';
 import Condition from '../../modules/condition';
 import Table from '../../modules/table';
 import { setBreadcrumbs } from '../../shared/layout/navigation/navigation.reducer';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { IProject } from '../../shared/model/project.model';
 import { IReport } from '../../shared/model/report.model';
 import { IUser } from '../../shared/model/user.model';
@@ -46,6 +45,7 @@ import { ReportActionHandler } from './report.actions';
 import { reportColumns, resourceTypeOptions, scopeOptions, visibleReportColumns } from './report.columns';
 import { ReportScope, createReport, downloadReport, listReports } from './report.service';
 import ContentLayout from '../../shared/layout/content-layout';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export function Report () {
     const dispatch = useAppDispatch();
@@ -55,7 +55,7 @@ export function Report () {
     const [loadingReports, setLoadingReports] = useState(false);
     const [reports, setReports] = useState([] as IReport[]);
     const [downloadReportUrl, setDownloadReportUrl] = useState('');
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const { projectName } = useParams();
     const [selectedTargets, setSelectedTargets] = useState([] as string[]);
 

--- a/frontend/src/entities/translate-realtime/translate-realtime.document.tsx
+++ b/frontend/src/entities/translate-realtime/translate-realtime.document.tsx
@@ -25,10 +25,10 @@ import {
 } from '../../shared/model/translate.model';
 import { scrollToInvalid } from '../../shared/validation';
 import { AxiosError, AxiosResponse } from 'axios';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { useAppDispatch } from '../../config/store';
 import { findOptionByValue } from '../../shared/util/select-utils';
 import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
+import { useNotificationService } from '../../shared/util/hooks';
 
 /**
  * The React component that populates the 'Document' tab for Translate real-time
@@ -57,7 +57,7 @@ export const TranslateRealtimeDocument = () => {
     const [formSubmitting, setFormSubmitting] = useState(false);
     const translateDocErrorRegex = /TranslateDocument operation: /gm;
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     const documentFormSchema = z.object({
         Document: z.object({

--- a/frontend/src/modules/dataset/dataset-browser.tsx
+++ b/frontend/src/modules/dataset/dataset-browser.tsx
@@ -31,9 +31,9 @@ import { upperFirst } from 'lodash';
 import { getMatchesCountText } from '../../shared/util/table-utils';
 import { EmptyState } from '../table';
 import { DatasetBrowserProps } from './dataset-browser.types';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { useUsername } from '../../shared/util/auth-utils';
 import '../../entities/dataset/dataset.scss';
+import { useNotificationService } from '../../shared/util/hooks';
 
 
 export function DatasetBrowser (props: DatasetBrowserProps) {
@@ -66,9 +66,7 @@ export function DatasetBrowser (props: DatasetBrowserProps) {
     const displayMode = displayModeForDatasetContext(state.datasetContext);
 
     // memoize notification service so it doesn't cause infinite loops when used in react hooks for fetchDatasetResources & fetchDatasets
-    const notificationService = useMemo(() => {
-        return NotificationService(dispatch);
-    }, [dispatch]);
+    const notificationService = useNotificationService(dispatch);
 
     const fetchDatasetResources = useCallback((datasetContext: Partial<DatasetContext>, nextToken?: string, existingItems?: (DatasetResource | IDataset)[]) => {
         if (!isCreating) {

--- a/frontend/src/modules/modal/delete-modal.tsx
+++ b/frontend/src/modules/modal/delete-modal.tsx
@@ -19,10 +19,10 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { AxiosResponse } from 'axios';
 import React, { useState } from 'react';
 import { useAppDispatch } from '../../config/store';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { CallbackFunction } from '../../types';
 import { dismissModal } from './modal.reducer';
 import { deleteButtonAriaLabel } from '../../entities/dataset/dataset.utils';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export type DeleteModalProps = {
     resourceName: string;
@@ -52,7 +52,7 @@ function DeleteModal ({
 }: DeleteModalProps) {
     const [processing, setProcessing] = useState(false);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const responseHandler = (
         response: PayloadAction<any, string> | AxiosResponse<any, any> | undefined
     ) => {

--- a/frontend/src/modules/modal/resource-schedule-modal.tsx
+++ b/frontend/src/modules/modal/resource-schedule-modal.tsx
@@ -28,13 +28,13 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { AxiosResponse } from 'axios';
 import React, { useState } from 'react';
 import { useAppDispatch } from '../../config/store';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { dismissModal } from './modal.reducer';
 import { formatTerminationTimestamp, timezoneDisplayString } from '../../shared/util/date-utils';
 import { CallbackFunction } from '../../types';
 import { initCap } from '../../shared/util/enum-utils';
 import { getTerminationHourDate } from '../../shared/util/resource-schedule.service';
 import { Timezone } from '../../shared/model/user.model';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export const editScheduleButtonAriaLabel = 'Edit resource auto-termination schedule';
 
@@ -70,7 +70,7 @@ function ResourceScheduleModal ({
 }: ResourceScheduleModalProps) {
     const [processing, setProcessing] = useState(false);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const existingTerminationTimestamp =
         resourceTerminationTime && new Date(resourceTerminationTime * 1000);
     const responseHandler = (

--- a/frontend/src/modules/modal/update-modal.tsx
+++ b/frontend/src/modules/modal/update-modal.tsx
@@ -21,9 +21,9 @@ import React, { useState } from 'react';
 import { IProjectUser } from '../../shared/model/projectUser.model';
 import { IUser } from '../../shared/model/user.model';
 import { useAppDispatch } from '../../config/store';
-import NotificationService from '../../shared/layout/notification/notification.service';
 import { CallbackFunction } from '../../types';
 import { dismissModal } from './modal.reducer';
+import { useNotificationService } from '../../shared/util/hooks';
 
 export type UpdateModalProps = {
     selectedUser: IUser | IProjectUser;
@@ -35,7 +35,7 @@ export type UpdateModalProps = {
 function UpdateModal ({ selectedUser, onConfirm, postConfirm, description }: UpdateModalProps) {
     const [processing, setProcessing] = useState(false);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const username = (selectedUser as IUser).username || (selectedUser as IProjectUser).user;
 
     const responseHandler = (

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -35,14 +35,14 @@ import keyLogo  from './shared/media/key.png';
 import groupLogo  from './shared/media/group.png';
 import docsLogo  from './shared/media/docs.png';
 import './routes.css';
-import NotificationService from './shared/layout/notification/notification.service';
 import { failedToLoadConfig, getConfiguration } from './entities/configuration/configuration-reducer';
+import { useNotificationService } from './shared/util/hooks';
 
 export default function AppRoutes () {
     const auth = useAuth();
     const currentUser = useAppSelector(selectCurrentUser);
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
     const notifiedError = useRef(false);
     const configLoadError: boolean = useAppSelector(failedToLoadConfig);
 

--- a/frontend/src/shared/layout/header/header.tsx
+++ b/frontend/src/shared/layout/header/header.tsx
@@ -21,15 +21,15 @@ import { useAuth } from 'react-oidc-context';
 import Condition from '../../../modules/condition';
 import { Timezone } from '../../model/user.model';
 import { selectCurrentUser, updateUser } from '../../../entities/user/user.reducer';
-import NotificationService from '../notification/notification.service';
 import { Mode, applyMode } from '@cloudscape-design/global-styles';
+import { useNotificationService } from '../../util/hooks';
 
 export default function Header () {
     const auth = useAuth();
     const currentUser = useAppSelector(selectCurrentUser);
 
     const dispatch = useAppDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     return (
         <CloudscapeHeader

--- a/frontend/src/shared/layout/notification/notification.tsx
+++ b/frontend/src/shared/layout/notification/notification.tsx
@@ -19,8 +19,8 @@ import React, { useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useAppSelector } from '../../../config/store';
 import { reset } from './notification.reducer';
-import NotificationService from './notification.service';
 import { NotificationProp } from './notifications.props';
+import { useNotificationService } from '../../util/hooks';
 
 function NotificationBanner () {
     const notifications: NotificationProp[] = useAppSelector(
@@ -29,7 +29,7 @@ function NotificationBanner () {
     const notificationDisplayMaxSize = 5;
 
     const dispatch = useDispatch();
-    const notificationService = NotificationService(dispatch);
+    const notificationService = useNotificationService(dispatch);
 
     useMemo(() => {
         dispatch(reset());

--- a/frontend/src/shared/util/hooks.ts
+++ b/frontend/src/shared/util/hooks.ts
@@ -14,8 +14,10 @@
   limitations under the License.
 */
 
+import { Action, ThunkDispatch } from '@reduxjs/toolkit';
 import { DebouncedFunc, debounce } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import NotificationService from '../layout/notification/notification.service';
 
 /**
  * A custom hook that runs an action periodically in the background to refresh data.
@@ -72,4 +74,11 @@ export function useDebounce<T extends (...args: any[]) => void> (callback: T, de
     const debounced = useMemo(() => debounce(callback, delay), [callback, delay]);
     
     return useCallback(debounced, [debounced]);
+}
+
+/**
+ * Creates a memoized NotificationService based on {@link dispatch}
+ */
+export function useNotificationService (dispatch: ThunkDispatch<any, any, Action>) {
+    return useMemo(() => NotificationService(dispatch), [dispatch]);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Everywhere in the project was using `NotificationService()` method which was run every render and always creates a new object. This making passing the result to other hooks impossible because they'll run every render.

This PR adds a hook that memoizes the call so we aren't creating new objects unnecessarily and it is easier to pass the result to other hooks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
