### PR TITLE
Bug: Extra / in path for labeling templates

### DIFF
--- a/backend/test/utils/test_get_groundtruth_utils.py
+++ b/backend/test/utils/test_get_groundtruth_utils.py
@@ -64,7 +64,7 @@ class GroundTruthUtilsTest(unittest.TestCase):
         bucket_name = "bucketName"
         job_name = "JobName"
         output_dir = "outputDir"
-        s3_key = f"{output_dir}/{job_name}/annotation-tool/data.json"
+        s3_key = f"{output_dir}{job_name}/annotation-tool/data.json"
         labels = [{"Key": "Value"}]
         assert generate_labels_configuration_file(labels, job_name, bucket_name, "outputDir") == f"s3://{bucket_name}/{s3_key}"
         mock_s3.put_object.assert_called_with(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The UI requires that output paths are suffixed with a `/` but the backend was still adding a `/` when concatenating. This is fixes the issue but we should fix this in a smarter way probably with normalizing paths so we can't end up in this situation again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
