### PR TITLE
hotfix: added normalization to labeling job output path

### DIFF
--- a/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
+++ b/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+import os
 
 import boto3
 
@@ -84,7 +85,9 @@ def create(event, context):
     labeling_job["LabelingJobName"] = labeling_job_name
 
     # Generate labels config file and store in S3 bucket
-    output_path = labeling_job["OutputConfig"]["S3OutputPath"].replace("s3://{}/".format(data_bucket_name), "")
+    stripped_protocol_output_path = labeling_job["OutputConfig"]["S3OutputPath"].removeprefix("s3://")
+    stripped_bucket_output_path = os.path.join(*stripped_protocol_output_path.split("/")[1:])
+    output_path = os.path.normpath(stripped_bucket_output_path)
     labeling_job["LabelCategoryConfigS3Uri"] = generate_labels_configuration_file(
         labeling_job_request["Labels"], labeling_job_name, data_bucket_name, output_path
     )

--- a/backend/src/ml_space_lambda/utils/groundtruth_utils.py
+++ b/backend/src/ml_space_lambda/utils/groundtruth_utils.py
@@ -120,7 +120,7 @@ def get_auto_labeling_arn(task_type: TaskTypes):
 
 def generate_labels_configuration_file(labels: list, job_name: str, data_bucket_name: str, output_dir_key: str) -> str:
     labels_config = {"document-version": "2018-11-28", "labels": labels}
-    s3_key = f"{output_dir_key}/{job_name}/annotation-tool/data.json"
+    s3_key = os.path.join(output_dir_key, job_name, "annotation-tool/data.json")
     s3.put_object(Bucket=data_bucket_name, Key=s3_key, Body=json.dumps(labels_config))
     return f"s3://{data_bucket_name}/{s3_key}"
 
@@ -161,8 +161,10 @@ def generate_ui_template(
                     file_content.append(line.replace("DESCRIPTION_STUB", description))
                 else:
                     file_content.append(line)
-        template_key = f"{output_dir_key}/{job_name}/annotation-tool/template.liquid"
+
+        template_key = os.path.join(output_dir_key, job_name, "annotation-tool/template.liquid")
         s3.put_object(Bucket=data_bucket_name, Key=template_key, Body="\n".join(file_content))
+
+        return f"s3://{data_bucket_name}/{template_key}"
     else:
         raise Exception(f"Labeling job template for {template_path} does not exist.")
-    return f"s3://{data_bucket_name}/{template_key}" if template_key is not None else None

--- a/backend/test/labeling_job/test_create_labeling_job.py
+++ b/backend/test/labeling_job/test_create_labeling_job.py
@@ -98,7 +98,7 @@ def test_create_labeling_job(
         "tags": generate_tags("auser", "myproject", "mlspace"),
     }
     mock_sagemaker.create_labeling_job.assert_called_with(**create_labeling_job(**args))
-    mock_generate_labels_configuration_file.assert_called_with([], "myjob", data_bucket_name, "s3://mybucket/path/to/output")
+    mock_generate_labels_configuration_file.assert_called_with([], "myjob", data_bucket_name, "path/to/output")
 
     # check happy path with app role
     mock_get_environment_variables.return_value = {

--- a/backend/test/utils/test_get_groundtruth_utils.py
+++ b/backend/test/utils/test_get_groundtruth_utils.py
@@ -73,6 +73,22 @@ class GroundTruthUtilsTest(unittest.TestCase):
             Body=json.dumps({"document-version": "2018-11-28", "labels": labels}),
         )
 
+    @mock.patch("ml_space_lambda.utils.groundtruth_utils.s3")
+    def test_generate_labels_configuration_file_with_trialing_slash(self, mock_s3):
+        bucket_name = "bucketName"
+        job_name = "JobName"
+        output_dir = "outputDir"
+        s3_key = f"{output_dir}/{job_name}/annotation-tool/data.json"
+        labels = [{"Key": "Value"}]
+        assert (
+            generate_labels_configuration_file(labels, job_name, bucket_name, "outputDir/") == f"s3://{bucket_name}/{s3_key}"
+        )
+        mock_s3.put_object.assert_called_with(
+            Bucket=bucket_name,
+            Key=s3_key,
+            Body=json.dumps({"document-version": "2018-11-28", "labels": labels}),
+        )
+
     @mock.patch("ml_space_lambda.utils.groundtruth_utils.boto3")
     def test_get_groundtruth_assets_domain(self, mock_boto3):
         mock_session = mock_boto3.session.Session()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Stop assuming datasets URIs have (or don't) a trailing slash.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
