### PR TITLE
Added table parameter keepSelection

### DIFF
--- a/frontend/src/entities/group/detail/add-group-user-modal.tsx
+++ b/frontend/src/entities/group/detail/add-group-user-modal.tsx
@@ -74,6 +74,7 @@ export function AddGroupUserModal (props: AddGroupUserModalProps) {
                     columnDefinitions={userColumns}
                     visibleColumns={addUserVisibleColumns}
                     variant='embedded'
+                    keepSelection={props.visible}
                 />
             </SpaceBetween>
         </Modal>

--- a/frontend/src/modules/table/table.tsx
+++ b/frontend/src/modules/table/table.tsx
@@ -70,6 +70,7 @@ export default function Table ({
     serverFetch,
     serverRequestProps,
     storeClear,
+    keepSelection = true,
 }: TableProps) {
     const currentUser = useAppSelector(selectCurrentUser);
     const dispatch = useDispatch();
@@ -89,7 +90,7 @@ export default function Table ({
             },
             pagination: { pageSize: preferences.pageSize },
             sorting: {},
-            selection: {keepSelection: true},
+            selection: {keepSelection},
         });
 
     const { selectedItems } = collectionProps;

--- a/frontend/src/modules/table/table.types.tsx
+++ b/frontend/src/modules/table/table.types.tsx
@@ -58,6 +58,7 @@ type TableProps<Entry = TableEntry> = {
     serverRequestProps?: ServerRequestProps;
     serverFetch?: AsyncThunk<any, ServerRequestProps, any>;
     storeClear?: ActionCreatorWithoutPayload;
+    keepSelection?: boolean
 };
 
 type TableEntry = any;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Because we don't have direct control over the selection inside a table a parameter was added so that we can control of the selection is persisted between table changes. This helps resolve an issue where selected items were troublesomely persistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
