### PR TITLE
Fixed useNotificationService usages causing errors

### DIFF
--- a/frontend/src/entities/batch-translate/batch-translate.actions.tsx
+++ b/frontend/src/entities/batch-translate/batch-translate.actions.tsx
@@ -22,6 +22,7 @@ import { stopBatchTranslateJob } from './batch-translate.reducer';
 import { useAppDispatch } from '../../config/store';
 import { BatchTranslateResourceMetadata } from '../../shared/model/resource-metadata.model';
 import { useNotificationService } from '../../shared/util/hooks';
+import { INotificationService } from '../../shared/layout/notification/notification.service';
 
 function BatchTranslateActions (props?: any) {
     const navigate = useNavigate();
@@ -45,6 +46,7 @@ function BatchTranslateActionButton (
     props?: any
 ) {
     const selectedTranslateJob = props?.selectedItems[0];
+    const notificationService = useNotificationService(dispatch);
 
     return (
         <ButtonDropdown
@@ -55,7 +57,7 @@ function BatchTranslateActionButton (
             variant='primary'
             disabled={selectedTranslateJob === undefined}
             onItemClick={(e) =>
-                BatchTranslateActionHandler(e, selectedTranslateJob, nav, dispatch, projectName)
+                BatchTranslateActionHandler(e, selectedTranslateJob, nav, dispatch, projectName, notificationService)
             }
         >
             Actions
@@ -84,9 +86,9 @@ const BatchTranslateActionHandler = async (
     batchJob: BatchTranslateResourceMetadata,
     nav: any,
     dispatch: ThunkDispatch<any, any, Action>,
-    projectName: string
+    projectName: string,
+    notificationService: INotificationService
 ) => {
-    const notificationService = useNotificationService(dispatch);
     let response: any | undefined = undefined;
     switch (e.detail.id) {
         case 'details':

--- a/frontend/src/entities/group/detail/group-detail-user.actions.tsx
+++ b/frontend/src/entities/group/detail/group-detail-user.actions.tsx
@@ -28,6 +28,7 @@ import { IUser, Permission } from '../../../shared/model/user.model';
 import { hasPermission } from '../../../shared/util/permission-utils';
 import { useNotificationService } from '../../../shared/util/hooks';
 import { selectCurrentUser } from '../../user/user.reducer';
+import { INotificationService } from '../../../shared/layout/notification/notification.service';
 
 function GroupDetailUserActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -54,6 +55,7 @@ function GroupDetailUserActions (props?: any) {
 function GroupDetailUserActionsButton (navigate: NavigateFunction, dispatch: Dispatch, currentUser: IUser, setAddUserModalVisible: (boolean) => void, props?: any) {
     const selectedUser: IGroupUser = props?.selectedItems[0];
     const items: ButtonDropdownProps.Item[] = [];
+    const notificationService = useNotificationService(dispatch);
     if (selectedUser) {
         items.push({
             text: 'Remove from Group',
@@ -74,7 +76,7 @@ function GroupDetailUserActionsButton (navigate: NavigateFunction, dispatch: Dis
                     items={items}
                     variant='primary'
                     disabled={!selectedUser}
-                    onItemClick={(e) => GroupDetailUserActionHandler(e, dispatch, modalState as ModalProps, setModalState, selectedUser)}
+                    onItemClick={(e) => GroupDetailUserActionHandler(e, dispatch, modalState as ModalProps, setModalState, selectedUser, notificationService)}
                 >
                     Actions
                 </ButtonDropdown>
@@ -95,10 +97,9 @@ const GroupDetailUserActionHandler = async (
     dispatch:  ThunkDispatch<any, any, Action>,
     modalState: ModalProps,
     setModalState: (state: Partial<ModalProps>) => void,
-    selectedUser: IGroupUser
+    selectedUser: IGroupUser,
+    notificationService: INotificationService
 ) => {
-    const notificationService = useNotificationService(dispatch);
-
     switch (e.detail.id) {
         case 'removeFromGroup':
             dispatch(

--- a/frontend/src/entities/jobs/transform/transform.actions.tsx
+++ b/frontend/src/entities/jobs/transform/transform.actions.tsx
@@ -22,6 +22,7 @@ import { Action, ThunkDispatch } from '@reduxjs/toolkit';
 import { useAppDispatch } from '../../../config/store';
 import { TransformJobResourceMetadata } from '../../../shared/model/resource-metadata.model';
 import { useNotificationService } from '../../../shared/util/hooks';
+import { INotificationService } from '../../../shared/layout/notification/notification.service';
 
 function BatchTransformJobActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -53,6 +54,7 @@ function BatchTransformJobActionButton (
     navigate: NavigateFunction,
     props?: any
 ) {
+    const notificationService = useNotificationService(dispatch);
     const selectedJob = props?.selectedItems[0];
 
     return (
@@ -68,7 +70,7 @@ function BatchTransformJobActionButton (
             variant='primary'
             disabled={selectedJob === undefined}
             onItemClick={(e) =>
-                BatchTransformJobActionHandler(e, selectedJob, projectName, dispatch, navigate)
+                BatchTransformJobActionHandler(e, selectedJob, projectName, dispatch, navigate, notificationService)
             }
         >
             Actions
@@ -81,9 +83,9 @@ const BatchTransformJobActionHandler = (
     transform: TransformJobResourceMetadata,
     projectName: string,
     dispatch: ThunkDispatch<any, any, Action>,
-    navigate: NavigateFunction
+    navigate: NavigateFunction,
+    notificationService: INotificationService
 ) => {
-    const notificationService = useNotificationService(dispatch);
     switch (e.detail.id) {
         case 'stop':
             stopTransformJob({ jobName: transform.resourceId, projectName: projectName }).then(

--- a/frontend/src/entities/notebook/notebook.actions.tsx
+++ b/frontend/src/entities/notebook/notebook.actions.tsx
@@ -31,6 +31,7 @@ import { NotebookResourceMetadata } from '../../shared/model/resource-metadata.m
 import { isAdminOrProjectOwner } from '../../shared/util/permission-utils';
 import { deletionDescription } from '../../shared/util/form-utils';
 import { useNotificationService } from '../../shared/util/hooks';
+import { INotificationService } from '../../shared/layout/notification/notification.service';
 
 function NotebookActions (props?: any) {
     const dispatch = useAppDispatch();
@@ -59,6 +60,7 @@ function NotebookActionButton (
     projectName?: string,
     props?: any
 ) {
+    const notificationService = useNotificationService(dispatch);
     const selectedNotebook: NotebookResourceMetadata = props?.selectedItems[0];
     const loadingAction = props?.loadingAction;
     const notebookStopped = ['Stopped', 'Failed'].includes(
@@ -112,7 +114,7 @@ function NotebookActionButton (
             disabled={selectedNotebook === undefined}
             loading={loadingAction}
             onItemClick={(e) =>
-                NotebookActionHandler(e, selectedNotebook, nav, dispatch, projectName)
+                NotebookActionHandler(e, selectedNotebook, nav, dispatch, notificationService, projectName)
             }
         >
             Actions
@@ -143,10 +145,10 @@ const NotebookActionHandler = async (
     notebook: NotebookResourceMetadata,
     nav: (endpoint: string) => void,
     dispatch: ThunkDispatch<any, any, Action>,
-    projectName?: string
+    notificationService: INotificationService,
+    projectName?: string,
 ) => {
     const basePath = projectName ? `/project/${projectName}` : '/personal';
-    const notificationService = useNotificationService(dispatch);
 
     let response: any | undefined = undefined;
     switch (e.detail.id) {

--- a/frontend/src/entities/project/detail/project-detail.actions.tsx
+++ b/frontend/src/entities/project/detail/project-detail.actions.tsx
@@ -28,6 +28,7 @@ import { hasPermission } from '../../../shared/util/permission-utils';
 import { Permission } from '../../../shared/model/user.model';
 import Modal, { ModalProps } from '../../../modules/modal';
 import { useNotificationService } from '../../../shared/util/hooks';
+import { INotificationService } from '../../../shared/layout/notification/notification.service';
 
 function ProjectDetailActions () {
     const dispatch = useAppDispatch();
@@ -57,6 +58,7 @@ function ProjectActionButton (
     const actionItems: Array<ButtonDropdownProps.ItemOrGroup> = [];
     const currentUser = useAppSelector(selectCurrentUser);
     const projectPermissions = useAppSelector((state) => state.project.permissions);
+    const notificationService = useNotificationService(dispatch);
 
     const [modalState, setModalState] = React.useState<Partial<ModalProps>>({
         visible: false,
@@ -104,7 +106,8 @@ function ProjectActionButton (
                     nav,
                     dispatch,
                     modalState as ModalProps,
-                    setModalState
+                    setModalState,
+                    notificationService
                 )
             }
         >
@@ -121,9 +124,9 @@ const ProjectActionHandler = (
     nav: (endpoint: string) => void,
     dispatch: ThunkDispatch<any, any, Action>,
     modalState: ModalProps,
-    setModalState: (state: Partial<ModalProps>) => void
+    setModalState: (state: Partial<ModalProps>) => void,
+    notificationService: INotificationService
 ) => {
-    const notificationService = useNotificationService(dispatch);
 
     switch (e.detail.id) {
         case 'update':

--- a/frontend/src/entities/report/report.actions.tsx
+++ b/frontend/src/entities/report/report.actions.tsx
@@ -16,15 +16,14 @@
 
 import { deleteReport } from './report.service';
 import { Action, ThunkDispatch } from '@reduxjs/toolkit';
-import { useNotificationService } from '../../shared/util/hooks';
+import { INotificationService } from '../../shared/layout/notification/notification.service';
 
 function ReportActionHandler (
     e: any,
     reportName: string,
-    dispatch: ThunkDispatch<any, any, Action>
+    dispatch: ThunkDispatch<any, any, Action>,
+    notificationService: INotificationService
 ) {
-    const notificationService = useNotificationService(dispatch);
-
     switch (e.detail.id) {
         case 'deleteReport':
             try {

--- a/frontend/src/entities/report/report.tsx
+++ b/frontend/src/entities/report/report.tsx
@@ -117,7 +117,7 @@ export function Report () {
                     variant='primary'
                     disabled={!props?.selectedItems[0]}
                     onItemClick={(e) => {
-                        ReportActionHandler(e, props?.selectedItems[0].Name, dispatch);
+                        ReportActionHandler(e, props?.selectedItems[0].Name, dispatch, notificationService);
                         (async () => {
                             await listReports().then((result) => {
                                 // The list_objects_v2 API has a delay before the deleted report


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When I replaced all the instances of `NotificationService()` with the `useNotificationService()` hook it broke in some places where that was being called from a function. Hooks should only be called from inside components. This PR updates those usages to to pass in the `INotificationService` instead of instantiating it directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
