### PR TITLE
UI fixes

### DIFF
--- a/frontend/src/entities/notebook/notebook.columns.tsx
+++ b/frontend/src/entities/notebook/notebook.columns.tsx
@@ -15,7 +15,7 @@
 */
 
 import React from 'react';
-import { TableProps } from '@cloudscape-design/components';
+import { Link, TableProps } from '@cloudscape-design/components';
 import { formatDate } from '../../shared/util/date-utils';
 import { linkify, prettyStatus, sortStringValue } from '../../shared/util/table-utils';
 import { NotebookResourceMetadata } from '../../shared/model/resource-metadata.model';
@@ -53,6 +53,12 @@ const defaultColumns: TableProps.ColumnDefinition<NotebookResourceMetadata>[] = 
         sortingField: 'user',
         cell: (item) => item.user,
     },
+    {
+        id: 'project',
+        header: 'Project',
+        sortingField: 'project',
+        cell: (item) => (<Link href={`#/project/${item.project}`}>{item.project}</Link>)
+    }
 ];
 
 const visibleColumns: string[] = [
@@ -60,6 +66,7 @@ const visibleColumns: string[] = [
     'creationTime',
     'status',
     'instanceType',
+    'project',
     'createdBy',
 ];
 
@@ -73,6 +80,7 @@ const visibleContentPreference = {
                 { id: 'creationTime', label: 'Creation time' },
                 { id: 'status', label: 'Status' },
                 { id: 'instanceType', label: 'Instance type' },
+                { id: 'project', label: 'Project'},
                 { id: 'createdBy', label: 'Created by' },
             ],
         },

--- a/frontend/src/entities/user/detail/user-detail.tsx
+++ b/frontend/src/entities/user/detail/user-detail.tsx
@@ -90,7 +90,7 @@ export function UserDetail () {
 
                 <Tabs variant='container' tabs={[{
                     id: 'projects',
-                    label: 'Project Membership',
+                    label: 'Project membership',
                     content: (
                         <Table
                             tableName='Project'
@@ -114,7 +114,7 @@ export function UserDetail () {
                     )
                 }, {
                     id: 'groups',
-                    label: 'Group Membership',
+                    label: 'Group membership',
                     content: (
                         <Table
                             tableName='Group'

--- a/frontend/src/shared/layout/notification/notification-expandable-section.tsx
+++ b/frontend/src/shared/layout/notification/notification-expandable-section.tsx
@@ -27,7 +27,6 @@ function NotificationExpandableSection (props: ExpandableSectionProps) {
 
     return (
         <div onKeyDown={(event) => {
-            console.log(event.code);
             switch (event.code) {
                 case 'ArrowLeft': // left arrow
                     setExpanded(false);

--- a/frontend/src/shared/layout/notification/notification-expandable-section.tsx
+++ b/frontend/src/shared/layout/notification/notification-expandable-section.tsx
@@ -1,0 +1,51 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { ExpandableSection, ExpandableSectionProps } from '@cloudscape-design/components';
+import React, { useEffect, useRef, useState } from 'react';
+
+function NotificationExpandableSection (props: ExpandableSectionProps) {
+    const [expanded, setExpanded] = useState(props.expanded || props.defaultExpanded || false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        ref?.current?.focus();
+    }, [ref]);
+
+    return (
+        <div onKeyDown={(event) => {
+            console.log(event.code);
+            switch (event.code) {
+                case 'ArrowLeft': // left arrow
+                    setExpanded(false);
+                    break;
+                case 'ArrowRight': // right arrow
+                    setExpanded(true);
+                    break;
+                case 'Enter': // return
+                case 'Space': // space
+                    setExpanded(!expanded);
+                    break;
+            }
+        }} tabIndex={0} ref={ref}>
+            <ExpandableSection {...props} expanded={expanded} onChange={({detail}) => setExpanded(detail.expanded)}>
+                {props.children}
+            </ExpandableSection>
+        </div>
+    );
+}
+
+export default NotificationExpandableSection;

--- a/frontend/src/shared/layout/notification/notification.service.tsx
+++ b/frontend/src/shared/layout/notification/notification.service.tsx
@@ -14,13 +14,14 @@
   limitations under the License.
 */
 
-import { ExpandableSection, FlashbarProps } from '@cloudscape-design/components';
+import { FlashbarProps } from '@cloudscape-design/components';
 import { v4 } from 'uuid';
 import { addNotification, clearNotification } from './notification.reducer';
 import { Action, ThunkDispatch, isRejected } from '@reduxjs/toolkit';
 import { NotificationProp } from './notifications.props';
 import React from 'react';
 import { isFulfilled } from '@reduxjs/toolkit';
+import NotificationExpandableSection from './notification-expandable-section';
 
 function NotificationService (dispatch: ThunkDispatch<any, any, Action>) {
     function generateNotification (header: string, type: FlashbarProps.Type, id: string = v4(), content: React.ReactNode = null, dismissible = true) {
@@ -51,9 +52,9 @@ function NotificationService (dispatch: ThunkDispatch<any, any, Action>) {
         } else if (isRejected(result)) {
             generateNotification(`Failed to ${action}.`, 'error', undefined, (
                 result.error.message ? (
-                    <ExpandableSection headingTagOverride={'h5'} headerText={'Details'}>
+                    <NotificationExpandableSection headerText={'Details'} headingTagOverride={'h5'}>
                         {result.error.message}
-                    </ExpandableSection>
+                    </NotificationExpandableSection>
                 ) : <></>
             ));
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- When listing notebooks outside the context of a project, it is sometimes useful to see with which project a notebook is associated. Similarly, when showing all notebooks that belong to a project, it is not helpful to see that information because every notebook will be associated with the same project. This PR adds a column to display a notebook's project in a context-aware way.
- Fixed capitalization `Group Membership`/`Project Membership` -> `Group membership`/`Project membership`
- Enable focusing on error notifications and allowed using keyboard to expand/collapse


![Recording 2024-07-16 at 21 52 17](https://github.com/user-attachments/assets/a1ed43e9-992b-44e7-a5f1-1d1ab5aba667)

Fixed capitalization…
![Screenshot 2024-07-16 at 21 57 46](https://github.com/user-attachments/assets/099cc6a6-7923-4327-af5a-cab7b6a1768a)

Controlling the error notification with the keyboard…
![Recording 2024-07-16 at 21 59 23](https://github.com/user-attachments/assets/3013e066-bacf-46a6-8b99-7ece40776ad8)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
