### PR TITLE
Initial group dataset fixes

### DIFF
--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -192,6 +192,9 @@ def create_dataset(event, context):
     if dataset_type == DatasetType.GLOBAL:
         scope = "global"
         directory_name = f"global/datasets/{dataset_name}/"
+    elif dataset_type == DatasetType.GROUP:
+        scope = "group"
+        directory_name = f"group/datasets/{dataset_name}/"
     else:
         scope = body.get("datasetScope")  # username, group name, or project name for private/project scope respectively
         directory_name = f"{dataset_type}/{scope}/datasets/{dataset_name}/"
@@ -208,6 +211,7 @@ def create_dataset(event, context):
             description=body.get("datasetDescription", ""),
             location=dataset_location,
             created_by=event["requestContext"]["authorizer"]["principalId"],
+            is_group=dataset_type == DatasetType.GROUP,
         )
         dataset_dao.create(dataset)
         return {"status": "success", "dataset": dataset.to_dict()}

--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -211,7 +211,6 @@ def create_dataset(event, context):
             description=body.get("datasetDescription", ""),
             location=dataset_location,
             created_by=event["requestContext"]["authorizer"]["principalId"],
-            is_group=dataset_type == DatasetType.GROUP,
         )
         dataset_dao.create(dataset)
         return {"status": "success", "dataset": dataset.to_dict()}

--- a/backend/test/dataset/test_create_dataset.py
+++ b/backend/test/dataset/test_create_dataset.py
@@ -69,7 +69,7 @@ def generate_dataset_model(event: dict, scope: str, dataset_location: str, type:
         (DatasetType.GLOBAL, "global"),
         (DatasetType.PROJECT, "project_name"),
         (DatasetType.PRIVATE, "username"),
-        (DatasetType.GROUP, "group_name"),
+        (DatasetType.GROUP, "group"),
     ],
     ids=[
         "create_global_dataset",
@@ -84,7 +84,7 @@ def test_create_dataset_success(mock_s3, mock_dataset_dao, dataset_type: str, sc
     mock_event = generate_event(dataset_type, scope)
     mock_dataset_dao.get.return_value = None
 
-    if scope == DatasetType.GLOBAL:
+    if scope == DatasetType.GLOBAL or scope == DatasetType.GROUP:
         directory_name = f"{scope}/datasets/{test_dataset_name}/"
     else:
         directory_name = f"{dataset_type}/{scope}/datasets/{test_dataset_name}/"

--- a/frontend/src/entities/dataset/dataset.reducer.ts
+++ b/frontend/src/entities/dataset/dataset.reducer.ts
@@ -69,7 +69,7 @@ export const deleteFileFromDataset = createAsyncThunk(
     'dataset/remove_file_from_dataset',
     async ({ type, scope, datasetName, files }: any) => {
         for (const file of files) {
-            const requestUrl = `/dataset/${type}/${scope}/${datasetName}/${file}`;
+            const requestUrl = `v2/dataset/${type}/${scope}/${datasetName}/${file}`;
             await axios.delete<IDataset>(requestUrl);
         }
     }

--- a/frontend/src/entities/dataset/dataset.service.tsx
+++ b/frontend/src/entities/dataset/dataset.service.tsx
@@ -100,7 +100,7 @@ export const buildS3KeysForResourceObjects = (
             case DatasetType.GLOBAL:
                 return [`global/datasets/${datasetContext.name}/${resourceObject.key}`, resourceObject];
             case DatasetType.GROUP:
-                return [`group/${datasetContext.scope}/datasets/${datasetContext.name}/${resourceObject.key}`, resourceObject];
+                return [`group/datasets/${datasetContext.name}/${resourceObject.key}`, resourceObject];
         }
     });
 };

--- a/frontend/src/entities/dataset/dataset.utils.ts
+++ b/frontend/src/entities/dataset/dataset.utils.ts
@@ -23,7 +23,7 @@ export const validateName = function (datasetName: string) {
 };
 
 export const showAccessLevel = (dataset: IDataset) => {
-    if (dataset.type === DatasetType.PROJECT || dataset.type === DatasetType.GROUP) {
+    if (dataset.type === DatasetType.PROJECT) {
         return `${dataset.type}: ${dataset.scope}`;
     } else {
         return dataset.type;

--- a/frontend/src/modules/dataset/dataset-inline-create.tsx
+++ b/frontend/src/modules/dataset/dataset-inline-create.tsx
@@ -73,8 +73,6 @@ export function DatasetInlineCreate (props: DatasetInlineCreateProps) {
                 case DatasetType.PROJECT:
                     scopeAndType += `/${projectName}`;
                     break;
-                case DatasetType.GROUP:
-                    scopeAndType += `/${state.form.groupName}`;
             }
 
             onChange(new CustomEvent('onChange', { cancelable: false, detail: { value: `s3://${window.env.DATASET_BUCKET}/${scopeAndType}/datasets/${datasetContext.name}/` } }));

--- a/frontend/src/modules/dataset/dataset-selector.tsx
+++ b/frontend/src/modules/dataset/dataset-selector.tsx
@@ -66,7 +66,6 @@ export function DatasetResourceSelector (props: DatasetResourceSelectorProps) {
                     case DatasetType.PROJECT:
                         scope = `${projectName}`;
                         break;
-                    //TODO: need groupName for a Group scope
                 }
     
                 let isEmpty = true;

--- a/lib/stacks/api/datasets.ts
+++ b/lib/stacks/api/datasets.ts
@@ -98,7 +98,7 @@ export class DatasetsApiStack extends Stack {
                 resource: 'dataset',
                 description: 'Removes a file from a dataset',
                 // use a greedy path here so object keys containing '/' are fully matched
-                path: 'dataset/{type}/{scope}/{datasetName}/{file+}',
+                path: 'v2/dataset/{type}/{scope}/{datasetName}/{file+}',
                 method: 'DELETE',
                 environment: {
                     DATA_BUCKET: props.dataBucketName,


### PR DESCRIPTION
*Description of changes:* PR for group dataset changes we've discussed

* modifying the Groups dataset hierarchy so that a group dataset doesn't exist under a folder named after a group, but rather under the `mlspace-data-<accId>/group/datasets/` folder. This will enable us to support multi-group datasets since a dataset won't be tightly linked to a single goup
* prepending `v2/` to the dataset `delete_file` API path so that it won't cause any errors when deploying the path changes 

TODO:
* update the dataset reducer to point to the new endpoint
* make any frontend changes necessary for handling Group dataset scope in a similar way we deal with Global scope
* may need to make modifications to `iam_manager.py` so that the generated arn for Group datasets is correct


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
