### PR TITLE
Added DATA_BUCKET env var to registerAPIEndpoint function

### DIFF
--- a/lib/utils/apiFunction.ts
+++ b/lib/utils/apiFunction.ts
@@ -64,6 +64,7 @@ export function registerAPIEndpoint (
         code: Code.fromAsset(lambdaSourcePath),
         description: funcDef.description,
         environment: {
+            DATA_BUCKET: mlspaceConfig.DATA_BUCKET_NAME,
             DATASETS_TABLE: mlspaceConfig.DATASETS_TABLE_NAME,
             PROJECTS_TABLE: mlspaceConfig.PROJECTS_TABLE_NAME,
             PROJECT_USERS_TABLE: mlspaceConfig.PROJECT_USERS_TABLE_NAME,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some lambdas were missing the `DATA_BUCKET` environment variable. I added it to the `registerAPIEndpoint` so that it should be available in any lambda using that function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
