### PR TITLE
Create dataset labmda updating groups incorrectly

### DIFF
--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -45,7 +45,7 @@ s3_resource = boto3.resource("s3", config=retry_config)
 dataset_dao = DatasetDAO()
 group_user_dao = GroupUserDAO()
 group_dataset_dao = GroupDatasetDAO()
-iam = boto3.resource("iam", config=retry_config)
+iam = boto3.client("iam", config=retry_config)
 iam_manager = IAMManager(iam)
 
 dataset_description_regex = re.compile(r"[^\w\-\s'.]")

--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -232,7 +232,7 @@ def create_dataset(event, context):
 
         if dataset_type == DatasetType.GROUP:
             group_dataset_dao.create(GroupDatasetModel(dataset_name, scope))
-            iam_manager.update_groups(scope)
+            iam_manager.update_groups([scope])
 
         return {"status": "success", "dataset": dataset.to_dict()}
     else:

--- a/backend/src/ml_space_lambda/utils/iam_manager.py
+++ b/backend/src/ml_space_lambda/utils/iam_manager.py
@@ -597,7 +597,8 @@ class IAMManager:
     def update_groups(self, groups: list[str]) -> None:
         users_to_update = set()
         for group in groups:
-            users_to_update.update(group_user_dao.get_users_for_group(group))
+            for user in group_user_dao.get_users_for_group(group):
+                users_to_update.add(user.user)
 
         for username in users_to_update:
             self.update_user_policy(username)

--- a/backend/test/utils/test_iam_manager.py
+++ b/backend/test/utils/test_iam_manager.py
@@ -27,7 +27,7 @@ from ml_space_lambda.data_access_objects.group_dataset import GroupDatasetModel
 from ml_space_lambda.data_access_objects.group_user import GroupUserModel
 from ml_space_lambda.enums import DatasetType
 from ml_space_lambda.utils.common_functions import generate_tags
-from ml_space_lambda.utils.iam_manager import DYNAMIC_USER_ROLE_TAG, PROJECT_POLICY_VERSION, USER_POLICY_VERSION
+from ml_space_lambda.utils.iam_manager import DYNAMIC_USER_ROLE_TAG, PROJECT_POLICY_VERSION, USER_POLICY_VERSION, IAMManager
 
 DYNAMIC_USER_ROLE_NAME = "MLSpace-myproject1-0fb265a4573777a0442ec4c6edeaf707216a2f5b16aa"
 UNTAGGED_DYNAMIC_USER_ROLE_NAME = "MLSpace-myproject2-0fb265a4573777a0442ec4c6edeaf707216a2f5b16aa"
@@ -643,9 +643,12 @@ class TestIAMSupport(TestCase):
             VersionId="v2",
         )
 
-    @mock.patch("ml_space_lambda.utils.IAMManager.update_user_policy")
+    @mock.patch.object(IAMManager, "update_user_policy")
     @mock.patch("ml_space_lambda.utils.iam_manager.group_user_dao")
-    def update_groups(self, mock_group_user_dao, mock_update_user_policy):
-        mock_group_user_dao.get_users_for_group.side_effect = [["user1"], ["user2"]]
+    def test_update_groups(self, mock_group_user_dao, mock_update_user_policy):
+        mock_group_user_dao.get_users_for_group.side_effect = [
+            [GroupUserModel("user1", "group1")],
+            [GroupUserModel("user2", "group2")],
+        ]
         self.iam_manager.update_groups(["group1", "group2"])
-        mock_update_user_policy.assert_calls(mock.call("user1"), mock.call("user2"))
+        mock_update_user_policy.assert_has_calls([mock.call("user1"), mock.call("user2")])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`IAMManager::update_groups` expects and array of groups and the create dataset lambda was passing in a string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
