### PR TITLE
Fixing permission bounary for HPO jobs

### DIFF
--- a/frontend/docs/admin-guide/install.md
+++ b/frontend/docs/admin-guide/install.md
@@ -241,7 +241,7 @@ In order to create the default {{ $params.APPLICATION_NAME }} notebook policy an
             ],
             "Resource": [
                 "arn:{AWS_PARTITION}:sagemaker:{AWS_REGION}:{AWS_ACCOUNT}:training-job/*",
-                "arn:{AWS_PARTITION}:sagemaker:{AWS_REGION}:{AWS_ACCOUNT}:hyper-parameter-training-job/*"
+                "arn:{AWS_PARTITION}:sagemaker:{AWS_REGION}:{AWS_ACCOUNT}:hyper-parameter-tuning-job/*"
             ],
             "Effect": "Deny"
         },

--- a/lib/stacks/iam.ts
+++ b/lib/stacks/iam.ts
@@ -418,7 +418,7 @@ export class IAMStack extends Stack {
                         ],
                         resources: [
                             `arn:${partition}:sagemaker:${region}:${this.account}:training-job/*`,
-                            `arn:${partition}:sagemaker:${region}:${this.account}:hyper-parameter-training-job/*`
+                            `arn:${partition}:sagemaker:${region}:${this.account}:hyper-parameter-tuning-job/*`
                         ],
                         conditions: {
                             Null: {
@@ -467,7 +467,7 @@ export class IAMStack extends Stack {
                         ],
                         resources: [
                             `arn:${partition}:sagemaker:${region}:${this.account}:training-job/*`,
-                            `arn:${partition}:sagemaker:${region}:${this.account}:hyper-parameter-training-job/*`
+                            `arn:${partition}:sagemaker:${region}:${this.account}:hyper-parameter-tuning-job/*`
                         ],
                         conditions: {
                             Null: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Permission boundary was for `hyper-parameter-training-job` instead of `hyper-parameter-tuning-job`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
