### PR TITLE
Bugfix for creating group datasets

### DIFF
--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -342,8 +342,8 @@ def lambda_handler(event, context):
                             groups = target_scope.split(",")
                             # check that this user is a member of every group they're adding to the group dataset
                             is_valid_group_list = True
-                            for group_names in user_group_names:
-                                if group_names not in groups:
+                            for group in groups:
+                                if group not in user_group_names:
                                     is_valid_group_list = False
                             if is_valid_group_list:
                                 policy_statement["Effect"] = "Allow"

--- a/frontend/src/entities/project/detail/groups/project.groups.actions.tsx
+++ b/frontend/src/entities/project/detail/groups/project.groups.actions.tsx
@@ -25,7 +25,7 @@ import { useAppDispatch, useAppSelector } from '../../../../config/store';
 import {
     selectCurrentUser,
 } from '../../../user/user.reducer';
-import { isAdminOrOwner, togglePermission } from '../../../../shared/util/permission-utils';
+import { hasPermission, isAdminOrOwner, togglePermission } from '../../../../shared/util/permission-utils';
 import { useParams } from 'react-router-dom';
 import { useNotificationService } from '../../../../shared/util/hooks';
 import AddProjectGroupModal from './add-project-group-modal';
@@ -51,6 +51,7 @@ function ProjectGroupActions (props?: ProjectGroupActionProps) {
     const [performingAction, setPerformingAction] = useState<boolean>(false);
     const project = useAppSelector(selectProject);
     const allGroups = useAppSelector(selectAllGroups);
+    const currentUser = useAppSelector(selectCurrentUser);
     const addableGroups = allGroups.filter((group) => {
         return !props?.projectGroups?.map((project_group) => project_group.group)?.includes(group.name);
     });
@@ -69,8 +70,8 @@ function ProjectGroupActions (props?: ProjectGroupActionProps) {
     ];
 
     useEffect(() => {
-        dispatch(getAllGroups());
-    }, [dispatch]);
+        dispatch(getAllGroups(hasPermission(Permission.ADMIN, currentUser.permissions)));
+    }, [dispatch, currentUser.permissions]);
 
     return (
         <SpaceBetween direction='horizontal' size='xs'>

--- a/lib/stacks/api/projects.ts
+++ b/lib/stacks/api/projects.ts
@@ -88,6 +88,9 @@ export class ProjectsApiStack extends Stack {
                 description: 'Adds groups to a project',
                 path: 'project/{projectName}/groups',
                 method: 'POST',
+                environment: {
+                    DATA_BUCKET: props.dataBucketName,
+                },
             },
             {
                 name: 'update_project_group',
@@ -95,6 +98,9 @@ export class ProjectsApiStack extends Stack {
                 description: 'Change the role of an MLSpace group within a project',
                 path: 'project/{projectName}/groups/{groupName}',
                 method: 'PUT',
+                environment: {
+                    DATA_BUCKET: props.dataBucketName,
+                },
             },
             {
                 name: 'delete',
@@ -129,6 +135,9 @@ export class ProjectsApiStack extends Stack {
                 description: 'Removes a group from a project',
                 path: 'project/{projectName}/groups/{groupName}',
                 method: 'DELETE',
+                environment: {
+                    DATA_BUCKET: props.dataBucketName,
+                },
             },
             {
                 name: 'update',


### PR DESCRIPTION
*Description of changes:* Was making the mistake of checking if every group the user is a member of is the same as the list of groups a group dataset is being shared with.

In reality a user should be able to add a group dataset to a subset of all of the groups they're a member of.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
