### PR TITLE
batch translate input dataset must be a folder

### DIFF
--- a/backend/src/ml_space_lambda/project/lambda_functions.py
+++ b/backend/src/ml_space_lambda/project/lambda_functions.py
@@ -537,6 +537,8 @@ def delete(event, context):
                 if iam_role_arn:
                     iam_manager.remove_project_user_roles([iam_role_arn])
 
+        project_group_dao.delete(project_name, group.group_name)
+
     # Delete users associations and project itself
     # Check the deployment type to confirm IAM Vendor usage
     if env_variables[EnvVariable.MANAGE_IAM_ROLES]:

--- a/backend/src/ml_space_lambda/utils/iam_manager.py
+++ b/backend/src/ml_space_lambda/utils/iam_manager.py
@@ -397,8 +397,10 @@ class IAMManager:
             f"arn:{self.aws_partition}:s3:::{self.data_bucket}/private/{user}/*",
             f"arn:{self.aws_partition}:s3:::{self.data_bucket}/global/*",
         ]
+        resource_prefixes = [f"private/{user}/*", "global/*", "index/*"]
 
         dataset_arn_prefixes = set()
+        group_prefixes = set()
         for group in group_user_dao.get_groups_for_user(user):
             for group_dataset in group_dataset_dao.get_datasets_for_group(group.group):
                 dataset = dataset_dao.get(DatasetType.GROUP, group_dataset.dataset)
@@ -406,8 +408,10 @@ class IAMManager:
                     dataset_arn_prefixes.add(
                         f"arn:{self.aws_partition}:s3:::{self.data_bucket}/group/datasets/{dataset.name}/*"
                     )
+                    group_prefixes.add(f"group/datasets/{dataset.name}/*")
 
         resource_arns.extend(list(dataset_arn_prefixes))
+        resource_prefixes.extend(list(group_prefixes))
 
         user_policy = {
             "Version": "2012-10-17",
@@ -426,7 +430,7 @@ class IAMManager:
                     "Effect": "Allow",
                     "Action": "s3:ListBucket",
                     "Resource": f"arn:{self.aws_partition}:s3:::{self.data_bucket}",
-                    "Condition": {"StringLike": {"s3:prefix": [f"private/{user}/*", "global/*", "index/*"]}},
+                    "Condition": {"StringLike": {"s3:prefix": resource_prefixes}},
                 },
                 {
                     "Effect": "Allow",

--- a/backend/test/project/test_delete_project.py
+++ b/backend/test/project/test_delete_project.py
@@ -78,6 +78,9 @@ def mock_project(suspened: Optional[bool] = True) -> ProjectModel:
     )
 
 
+@mock.patch("ml_space_lambda.project.lambda_functions.iam_manager")
+@mock.patch("ml_space_lambda.project.lambda_functions.group_user_dao")
+@mock.patch("ml_space_lambda.project.lambda_functions.project_group_dao")
 @mock.patch("ml_space_lambda.project.lambda_functions.resource_metadata_dao")
 @mock.patch("ml_space_lambda.project.lambda_functions.emr")
 @mock.patch("ml_space_lambda.project.lambda_functions.sagemaker")

--- a/backend/test/project/test_delete_project.py
+++ b/backend/test/project/test_delete_project.py
@@ -318,7 +318,7 @@ def test_delete_project_external_iam(
             group_name="TestGroup2",
             project_name=MOCK_PROJECT_NAME,
             permissions=[Permission.COLLABORATOR],
-        )
+        ),
     ]
 
     mock_group_user_dao.get_users_for_group.side_effect = [
@@ -328,7 +328,6 @@ def test_delete_project_external_iam(
                 group_name="TestGroup1",
                 permissions=[Permission.COLLABORATOR],
             ),
-
             GroupUserModel(
                 username="foo@example.com",
                 group_name="TestGroup1",
@@ -342,7 +341,7 @@ def test_delete_project_external_iam(
                 permissions=[Permission.COLLABORATOR],
             ),
         ],
-    ];
+    ]
 
     assert lambda_handler(mock_event, mock_context) == expected_response
 

--- a/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
+++ b/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
@@ -333,7 +333,7 @@ export function BatchTranslateCreate () {
                     <Container header={<Header variant='h2'>Input data</Header>}>
                         <DatasetResourceSelector
                             fieldLabel={'S3 Location'}
-                            selectableItemsTypes={['objects', 'prefixes']}
+                            selectableItemsTypes={['prefixes']}
                             onChange={({detail}) => {
                                 setFields({
                                     'InputDataConfig.S3Uri': detail.resource,

--- a/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
+++ b/frontend/src/entities/batch-translate/create/batch-translate-create.tsx
@@ -93,7 +93,7 @@ export function BatchTranslateCreate () {
         InputDataConfig: z.object({
             S3Uri: z
                 .string({ required_error: 'You must select an S3 input URI.' })
-                .s3Uri(),
+                .s3Prefix(),
             ContentType: z.string({ required_error: 'A content type must be selected.' }),
         }),
         OutputDataConfig: z.object({


### PR DESCRIPTION

*Description of changes:* batch translate will error if the user specifies a file instead of a folder for a dataset input, so lock down the selectable options to folders and don't allow the user to select files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
