### PR TITLE
Remove app config GET from authorizer and unit tests

### DIFF
--- a/backend/src/ml_space_lambda/authorizer/lambda_function.py
+++ b/backend/src/ml_space_lambda/authorizer/lambda_function.py
@@ -73,15 +73,6 @@ def lambda_handler(event, context):
         f"- Method: {request_method}"
     )
 
-    if requested_resource == "/app-config" and request_method == "GET":
-        # Anyone can get the app config
-        policy_statement["Effect"] = "Allow"
-        return {
-            "principalId": "Unknown",
-            "policyDocument": {"Version": "2012-10-17", "Statement": [policy_statement]},
-            "context": response_context,
-        }
-
     client_token = None
     token_failure = False
     auth_header = None

--- a/backend/test/authorizer/test_authorizer.py
+++ b/backend/test/authorizer/test_authorizer.py
@@ -1828,21 +1828,15 @@ def test_config_routes(mock_user_dao, user: UserModel, method: str, allow: bool)
     [
         (MOCK_USER, None, "POST", None, False),
         (MOCK_ADMIN_USER, None, "POST", None, True),
-        (MOCK_USER, None, "GET", None, True),
-        (MOCK_USER, MOCK_REGULAR_PROJECT_USER, "GET", {"projectName": MOCK_PROJECT_NAME}, True),
         (MOCK_USER, MOCK_REGULAR_PROJECT_USER, "POST", {"projectName": MOCK_PROJECT_NAME}, False),
         (MOCK_OWNER_USER, MOCK_OWNER_PROJECT_USER, "POST", {"projectName": MOCK_PROJECT_NAME}, True),
-        (None, None, "GET", None, True),
         (None, None, "POST", None, False),
     ],
     ids=[
         "user_update_app_config",
         "admin_update_app_config",
-        "user_get_app_config",
-        "user_get_project_config",
         "user_update_project_config",
         "project_owner_update_project_config",
-        "non_user_get_app_config",
         "non_user_update_app_config",
     ],
 )

--- a/lib/stacks/api/appConfiguration.ts
+++ b/lib/stacks/api/appConfiguration.ts
@@ -47,6 +47,7 @@ export class AppConfigurationApiStack extends Stack {
                 description: 'Get the requested number of MLSpace application configurations, starting from the most recent',
                 path: 'app-config',
                 method: 'GET',
+                noAuthorizer: true
             },
             {
                 name: 'update_configuration',

--- a/lib/utils/apiFunction.ts
+++ b/lib/utils/apiFunction.ts
@@ -38,6 +38,7 @@ export type MLSpacePythonLambdaFunction = {
     environment?: {
         [key: string]: string;
     };
+    noAuthorizer?: boolean
 };
 
 export function registerAPIEndpoint (
@@ -91,10 +92,13 @@ export function registerAPIEndpoint (
         securityGroups,
     });
     const functionResource = getOrCreateResource(stack, api.root, funcDef.path.split('/'));
-    functionResource.addMethod(funcDef.method, new LambdaIntegration(handler), {
+    const methodOptions = funcDef.noAuthorizer ? {
+        authorizationType: AuthorizationType.NONE
+    } : {
         authorizer,
         authorizationType: AuthorizationType.CUSTOM,
-    });
+    };
+    functionResource.addMethod(funcDef.method, new LambdaIntegration(handler), methodOptions);
 }
 
 function getOrCreateResource (stack: Stack, parentResource: IResource, path: string[]): IResource {


### PR DESCRIPTION
*Description of changes:* to ensure an app config GET request never fails due to 4XX errors or issues within the authorizer, make it so the app-config GET method isn't behind the authorizer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
