### PR TITLE
updating the stored value for history actioned_at to be in millis

### DIFF
--- a/backend/src/ml_space_lambda/data_access_objects/group_membership_history.py
+++ b/backend/src/ml_space_lambda/data_access_objects/group_membership_history.py
@@ -36,7 +36,7 @@ class GroupMembershipHistoryModel:
         actioned_by: str,
         actioned_at: Optional[float] = None,
     ):
-        now = int(time.time())
+        now = int(time.time() * 1000)
         self.user = username
         self.group = group_name
         self.action = action

--- a/backend/test/group/test_add_group_user.py
+++ b/backend/test/group/test_add_group_user.py
@@ -53,6 +53,12 @@ mock_event = {
 mock_context = mock.Mock()
 
 
+def _remove_actioned_at_attr(group_membership_hist: GroupMembershipHistoryModel) -> dict:
+    dictionary = group_membership_hist.to_dict()
+    dictionary.pop("actionedAt")
+    return dictionary
+
+
 @mock.patch("ml_space_lambda.group.lambda_functions.group_membership_history_dao")
 @mock.patch("ml_space_lambda.group.lambda_functions.project_group_dao")
 @mock.patch("ml_space_lambda.group.lambda_functions.group_dao")
@@ -90,14 +96,13 @@ def test_add_users_to_group_with_iam(
     mock_group_user_dao.create.assert_called_once()
     mock_project_group_dao.get_projects_for_group.assert_called_once()
     mock_group_membership_history_dao.create.assert_called_once()
-    assert (
-        mock_group_membership_history_dao.create.call_args.args[0].to_dict()
-        == GroupMembershipHistoryModel(
+    assert _remove_actioned_at_attr(mock_group_membership_history_dao.create.call_args.args[0]) == _remove_actioned_at_attr(
+        GroupMembershipHistoryModel(
             group_name=MOCK_GROUP_NAME,
             username=MOCK_USERNAME,
             action=GroupUserAction.ADDED,
             actioned_by=MOCK_USERNAME,
-        ).to_dict()
+        )
     )
 
     assert (
@@ -140,14 +145,13 @@ def test_add_users_to_group(
     # because the arg is a class so the comparison will fail due to pointer issues
     mock_group_user_dao.create.assert_called_once()
     mock_group_membership_history_dao.create.assert_called_once()
-    assert (
-        mock_group_membership_history_dao.create.call_args.args[0].to_dict()
-        == GroupMembershipHistoryModel(
+    assert _remove_actioned_at_attr(mock_group_membership_history_dao.create.call_args.args[0]) == _remove_actioned_at_attr(
+        GroupMembershipHistoryModel(
             group_name=MOCK_GROUP_NAME,
             username=MOCK_USERNAME,
             action=GroupUserAction.ADDED,
             actioned_by=MOCK_USERNAME,
-        ).to_dict()
+        )
     )
 
     assert (
@@ -233,32 +237,35 @@ def test_add_users_to_group_multiple(
     )
 
     assert mock_group_membership_history_dao.create.call_count == 3
-    assert (
-        mock_group_membership_history_dao.create.call_args_list[0].args[0].to_dict()
-        == GroupMembershipHistoryModel(
+    assert _remove_actioned_at_attr(
+        mock_group_membership_history_dao.create.call_args_list[0].args[0]
+    ) == _remove_actioned_at_attr(
+        GroupMembershipHistoryModel(
             group_name=MOCK_GROUP_NAME,
             username="user1",
             action=GroupUserAction.ADDED,
             actioned_by=MOCK_USERNAME,
-        ).to_dict()
+        )
     )
-    assert (
-        mock_group_membership_history_dao.create.call_args_list[1].args[0].to_dict()
-        == GroupMembershipHistoryModel(
+    assert _remove_actioned_at_attr(
+        mock_group_membership_history_dao.create.call_args_list[1].args[0]
+    ) == _remove_actioned_at_attr(
+        GroupMembershipHistoryModel(
             group_name=MOCK_GROUP_NAME,
             username="user2",
             action=GroupUserAction.ADDED,
             actioned_by=MOCK_USERNAME,
-        ).to_dict()
+        )
     )
-    assert (
-        mock_group_membership_history_dao.create.call_args_list[2].args[0].to_dict()
-        == GroupMembershipHistoryModel(
+    assert _remove_actioned_at_attr(
+        mock_group_membership_history_dao.create.call_args_list[2].args[0]
+    ) == _remove_actioned_at_attr(
+        GroupMembershipHistoryModel(
             group_name=MOCK_GROUP_NAME,
             username="user3",
             action=GroupUserAction.ADDED,
             actioned_by=MOCK_USERNAME,
-        ).to_dict()
+        )
     )
 
 

--- a/backend/test/group/test_delete_group.py
+++ b/backend/test/group/test_delete_group.py
@@ -121,15 +121,18 @@ def test_delete_group(
     mock_group_user_dao.delete.assert_called_with(MOCK_GROUP_NAME, mock_username)
 
     mock_group_membership_history_dao.create.assert_called_once()
-    assert (
-        mock_group_membership_history_dao.create.call_args_list[0].args[0].to_dict()
-        == GroupMembershipHistoryModel(
-            group_name=MOCK_GROUP_NAME,
-            username=mock_username,
-            action=GroupUserAction.GROUP_DELETED,
-            actioned_by=MOCK_USERNAME,
-        ).to_dict()
-    )
+
+    actual_history_arg = mock_group_membership_history_dao.create.call_args_list[0].args[0].to_dict()
+    actual_history_arg.pop("actionedAt")
+    expected_history_arg = GroupMembershipHistoryModel(
+        group_name=MOCK_GROUP_NAME,
+        username=mock_username,
+        action=GroupUserAction.GROUP_DELETED,
+        actioned_by=MOCK_USERNAME,
+    ).to_dict()
+    expected_history_arg.pop("actionedAt")
+
+    assert actual_history_arg == expected_history_arg
 
     if dynamic_roles:
         mock_iam_manager.update_user_policy.assert_called_with(mock_username)

--- a/backend/test/group/test_remove_user_from_group.py
+++ b/backend/test/group/test_remove_user_from_group.py
@@ -91,15 +91,18 @@ def test_remove_user_from_group_success(
     mock_iam_manager.get_iam_role_arn.assert_called_once()
     mock_iam_manager.remove_project_user_roles.assert_called_with([fake_role_arn])
     mock_group_membership_history_dao.create.assert_called_once()
-    assert (
-        mock_group_membership_history_dao.create.call_args_list[0].args[0].to_dict()
-        == GroupMembershipHistoryModel(
-            group_name=MOCK_GROUP_NAME,
-            username=MOCK_CO_USER.user,
-            action=GroupUserAction.REMOVED,
-            actioned_by=MOCK_USERNAME,
-        ).to_dict()
-    )
+
+    actual_history_arg = mock_group_membership_history_dao.create.call_args_list[0].args[0].to_dict()
+    actual_history_arg.pop("actionedAt")
+    expected_history_arg = GroupMembershipHistoryModel(
+        group_name=MOCK_GROUP_NAME,
+        username=MOCK_CO_USER.user,
+        action=GroupUserAction.REMOVED,
+        actioned_by=MOCK_USERNAME,
+    ).to_dict()
+    expected_history_arg.pop("actionedAt")
+
+    assert actual_history_arg == expected_history_arg
 
 
 @mock.patch("ml_space_lambda.group.lambda_functions.group_membership_history_dao")

--- a/frontend/src/entities/group/detail/group-detail-user.actions.tsx
+++ b/frontend/src/entities/group/detail/group-detail-user.actions.tsx
@@ -16,7 +16,7 @@
 
 import { useAppDispatch, useAppSelector } from '../../../config/store';
 import { Button, ButtonDropdown, ButtonDropdownProps, Icon, SpaceBetween } from '@cloudscape-design/components';
-import { currentGroupUsers, getGroupUsers, removeGroupUser } from '../group.reducer';
+import { currentGroupUsers, getGroupMembershipHistory, getGroupUsers, removeGroupUser } from '../group.reducer';
 import React, { useEffect, useState } from 'react';
 import { Action, Dispatch, ThunkDispatch } from '@reduxjs/toolkit';
 import { NavigateFunction, useNavigate, useParams } from 'react-router-dom';
@@ -127,6 +127,7 @@ const GroupDetailUserActionHandler = async (
                             );
                         }).finally(() => {
                             dispatch(getGroupUsers(selectedUser.group));
+                            dispatch(getGroupMembershipHistory(selectedUser.group));
                         });
                     },
                     description: `This will remove user: ${selectedUser.user} from the following group: ${selectedUser.group}.`

--- a/frontend/src/entities/group/detail/group-history.columns.tsx
+++ b/frontend/src/entities/group/detail/group-history.columns.tsx
@@ -42,7 +42,7 @@ export const groupHistoryColumns: TableProps.ColumnDefinition<IGroupMembershipHi
     id: 'actionedAt',
     header: 'Actioned At',
     sortingField: 'actionedAt',
-    cell: (item) => formatEpochTimestamp(item.actionedAt),
+    cell: (item) => formatEpochTimestamp(item.actionedAt, false, false),
 }];
 
 export const visibleGroupHistoryColumns: string[] = ['user', 'action', 'actionedBy', 'actionedAt'];

--- a/frontend/src/entities/group/user/group-user-functions.ts
+++ b/frontend/src/entities/group/user/group-user-functions.ts
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 import { Action, ThunkDispatch } from '@reduxjs/toolkit';
-import { AddGroupUserRequest, addGroupUsers, getGroupUsers } from '../group.reducer';
+import { AddGroupUserRequest, addGroupUsers, getGroupMembershipHistory, getGroupUsers } from '../group.reducer';
 import NotificationService from '../../../shared/layout/notification/notification.service';
 import { IUser } from '../../../shared/model/user.model';
 
@@ -42,5 +42,6 @@ export async function addUsersToGroup (
         );
     }).finally(() => {
         dispatch(getGroupUsers(groupName));
+        dispatch(getGroupMembershipHistory(groupName));
     });
 }

--- a/frontend/src/shared/util/date-utils.ts
+++ b/frontend/src/shared/util/date-utils.ts
@@ -226,7 +226,7 @@ export const hoursToDays = (hours: number | undefined): number | undefined => {
  * @param seconds whether or not the epoch time is in seconds (true) or milliseconds (false)
  * @returns display friendly string of date time in the users preferred timezone
  */
-export const formatEpochTimestamp = (epochTime: number, timeOnly: boolean = false, seconds: boolean = true) => {
+export const formatEpochTimestamp = (epochTime: number, timeOnly = false, seconds = true) => {
     const dateTime = seconds ? new Date(epochTime * 1000) : new Date(epochTime);
     if (timeOnly) {
         return dateTime.toLocaleTimeString('en-US', {

--- a/frontend/src/shared/util/date-utils.ts
+++ b/frontend/src/shared/util/date-utils.ts
@@ -223,10 +223,11 @@ export const hoursToDays = (hours: number | undefined): number | undefined => {
  *
  * @param epochTime datetime in the form of seconds since epoch
  * @param timeOnly whether or not the display string should be only include the time (notebooks)
+ * @param seconds whether or not the epoch time is in seconds (true) or milliseconds (false)
  * @returns display friendly string of date time in the users preferred timezone
  */
-export const formatEpochTimestamp = (epochTime: number, timeOnly = false) => {
-    const dateTime = new Date(epochTime * 1000);
+export const formatEpochTimestamp = (epochTime: number, timeOnly: boolean = false, seconds: boolean = true) => {
+    const dateTime = seconds ? new Date(epochTime * 1000) : new Date(epochTime);
     if (timeOnly) {
         return dateTime.toLocaleTimeString('en-US', {
             timeZone: 'UTC',


### PR DESCRIPTION
updating the stored value for history actioned_at to be in millis to prevent clashes when adding 3+ users

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
