### PR TITLE
Comprehensive dataset tests for project and private datasets

### DIFF
--- a/cypress/cypress/e2e/datasets.spec.cy.ts
+++ b/cypress/cypress/e2e/datasets.spec.cy.ts
@@ -14,7 +14,6 @@
   limitations under the License.
 */
 
-import { dataset } from './resources';
 import {
     BASE_URL,
     DEFAULT_USERNAME,
@@ -23,12 +22,11 @@ import {
 import createWrapper from '@cloudscape-design/components/test-utils/selectors';
 import { TestProps } from '../support/test-initializer/types';
 
+const testTime = new Date().getTime();
+
 describe('Dataset Tests', () => {
-    const testTime = new Date().getTime();
     const testProjectPrefix = 'Datasets';
     const testProjectName = `${testProjectPrefix}${testTime}`;
-    const datasetName = `e2eTestDataset${testTime}`;
-    const testDataset = { ...dataset, DatasetName: `${datasetName}`, ProjectName: `${testProjectName}` };
 
     const testProps: TestProps = {
         login: true,
@@ -56,151 +54,231 @@ describe('Dataset Tests', () => {
         cy.teardownTest(testProps);
     });
 
-    it('Create Dataset', () => {
-        cy.contains('Create dataset').click();
-        cy.url().should('include', '/dataset/create');
+    // === Global ===
 
-        // Set dataset values
-        cy.setValueCloudscapeInput('dataset-name-input', datasetName);
-        cy.setValueCloudscapeTextArea('dataset-description-textarea', testDataset.DatasetDescription);
-        cy.setValueCloudscapeSelect('dataset-type-select', testDataset.DatasetType.toLocaleLowerCase());
-        cy.get('[data-cy="dataset-file-upload-input-Upload Files"]').as('fileInput');
-        cy.fixture('test_upload_file.txt').then((fileContent) => {
-            cy.get('@fileInput').attachFile({
-                fileContent: fileContent.toString(),
-                fileName: 'test_upload_file.txt',
-                mimeType: testDataset.DatasetFormat
-            });
-        });
-
-        // Verify expected values were input and retained by the form
-        cy.verifyCloudscapeInput('dataset-name-input', datasetName);
-        cy.verifyCloudscapeTextArea('dataset-description-textarea', testDataset.DatasetDescription);
-        cy.verifyCloudscapeSelect('dataset-type-select', testDataset.DatasetType);
-        cy.get('[data-cy="dataset-submit-button"]').click();
-        cy.wait(2000);
-        
-        // Verify dataset creation redirected to main dataset page
-        cy.url().should('include', `#/project/${testProjectName}/dataset`).should('include', datasetName);
-
-        // Wait for the dataset to be populated and redirect to the datasets page
-        // Occasional failures to load were observed at 5000ms wait time in development
-        cy.visit(`${BASE_URL}#/project/${testProjectName}/dataset`);
-        cy.wait(2000);
-        cy.reload();
-
-        // Verify dataset was created
-        // Filter for the item so that it is the only one in the list
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
+    it('Create Global Dataset', () => {
+        createDataset('Global', testProjectName);
     });
 
-    it('Dataset Details', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Arbitrary wait for DOM to stabilize
-        cy.wait(1000);
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).click();
-
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).click();
-        cy.get(actionsDropdownWrapper.findItemById('details').toSelector()).click();
-
-        cy.get('[data-cy="Name-value"]').should('have.text', testDataset.DatasetName);
-        cy.get('[data-cy="Description-value"]').should('have.text', testDataset.DatasetDescription);
-        cy.get('[data-cy="Access level-value"]').should('have.text', testDataset.DatasetType.toLowerCase());
-        // Should not have the default empty text
-        cy.get('[data-cy="Location-value"]').should('not.have.text', '-');
+    it('Global Dataset Details', () => {
+        getDatasetDetails('Global');
     });
 
-    it('Delete Dataset File', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.findItemById('details').toSelector()).scrollIntoView().click();
-        cy.wait(2000);
-
-        // Filter for the uploaded file
-        const datasetBrowserTableWrapper = createWrapper().findTable('[data-cy="Dataset Browser"]');
-        cy.setValueCloudscapeInput('Filter files', 'test_upload_file.txt');
-        cy.get(datasetBrowserTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-        cy.contains('Delete').click();
-        cy.get('[data-cy="modal-delete"]').click();
-        cy.contains('No Entries exist');
+    it('Delete Global Dataset File', () => {
+        deleteDatasetFile('Global');
     });
 
-    it('Update Dataset', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.findItemById('edit').toSelector()).click();
-
-        // Check that expected values are available
-        cy.get(createWrapper().findInput('[data-cy="dataset-type"]').findNativeInput().toSelector()).should('have.value', testDataset.DatasetType.toLowerCase());
-        cy.get(createWrapper().findInput('[data-cy="dataset-owner"]').findNativeInput().toSelector()).should('have.value', DEFAULT_USERNAME);
-        cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).should('have.value', testDataset.DatasetDescription);
-
-        // Update description
-        cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).type(' Updated');
-
-        // Save description change
-        cy.contains('Update dataset').scrollIntoView().click();
-
-        // Saving the change redirects back to the dataset table
-        // Verify the description is updated in the table
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.toSelector()).click();
-        cy.get(actionsDropdownWrapper.findItemById('details').toSelector()).click();
-        cy.get('[data-cy="Description-value"]').should('have.text', `${testDataset.DatasetDescription} Updated`);
-
-        // Upload a new file
-        cy.get('[data-cy="dataset-file-upload-input-Upload Files"]').as('fileInput');
-        cy.fixture('test_upload_file.txt').then((fileContent) => {
-            cy.get('@fileInput').attachFile({
-                fileContent: fileContent.toString(),
-                fileName: 'test_second_upload_file.txt',
-                mimeType: testDataset.DatasetFormat
-            });
-        });
-        // Verify file was added
-        cy.contains('test_second_upload_file.txt');
+    it('Update Global Dataset', () => {
+        updateDataset('Global');
     });
 
-    it('Delete Dataset', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
+    it('Delete Global Dataset', () => {
+        deleteDataset('Global');
+    });
 
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.findItemById('delete').toSelector()).click();
-        cy.get('[data-cy="modal-delete"]').click();
+    // === Private ===
 
-        // Check that the dataset is deleted
-        cy.contains('0 matches');
+    it('Create Private Dataset', () => {
+        createDataset('Private', testProjectName);
+    });
+
+    it('Private Dataset Details', () => {
+        getDatasetDetails('Private');
+    });
+
+    it('Delete Private Dataset File', () => {
+        deleteDatasetFile('Private');
+    });
+
+    it('Update Private Dataset', () => {
+        updateDataset('Private');
+    });
+
+    it('Delete Private Dataset', () => {
+        deleteDataset('Private');
+    });
+
+    // === Project ===
+
+    it('Create Project Dataset', () => {
+        createDataset('Project', testProjectName);
+    });
+
+    it('Project Dataset Details', () => {
+        getDatasetDetails('Project', testProjectName);
+    });
+
+    it('Delete Project Dataset File', () => {
+        deleteDatasetFile('Project');
+    });
+
+    it('Update Project Dataset', () => {
+        updateDataset('Project');
+    });
+
+    it('Delete Project Dataset', () => {
+        deleteDataset('Project');
     });
 });
+
+// === Driver Functions ===
+function createDataset (datasetType: string, testProjectName: string) {
+    const datasetName = generateDatasetName(datasetType);
+    const datasetDescription = generateDatasetDescription(datasetType);
+    cy.contains('Create dataset').click();
+    cy.url().should('include', '/dataset/create');
+
+    // Set dataset values
+    cy.setValueCloudscapeInput('dataset-name-input', datasetName);
+    cy.setValueCloudscapeTextArea('dataset-description-textarea', datasetDescription);
+    cy.setValueCloudscapeSelect('dataset-type-select', datasetType.toLocaleLowerCase());
+
+    uploadFile('test_upload_file.txt');
+
+    // Verify expected values were input and retained by the form
+    cy.verifyCloudscapeInput('dataset-name-input', datasetName);
+    cy.verifyCloudscapeTextArea('dataset-description-textarea', datasetDescription);
+    cy.verifyCloudscapeSelect('dataset-type-select', datasetType);
+    cy.get('[data-cy="dataset-submit-button"]').click();
+    cy.wait(2000);
+    
+    // Verify dataset creation redirected to main dataset page
+    cy.url().should('include', `#/project/${testProjectName}/dataset`).should('include', datasetName);
+
+    // Wait for the dataset to be populated and redirect to the datasets page
+    // Occasional failures to load were observed at 5000ms wait time in development
+    cy.visit(`${BASE_URL}#/project/${testProjectName}/dataset`);
+    cy.wait(2000);
+    cy.reload();
+
+    filterDatasets(datasetName);
+}
+
+function getDatasetDetails (datasetType: string, testProjectName?: string) {
+    const datasetName = generateDatasetName(datasetType);
+    const datasetDescription = generateDatasetDescription(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click edit
+    clickAndAction('details');
+
+    cy.get('[data-cy="Name-value"]').should('have.text', datasetName);
+    cy.get('[data-cy="Description-value"]').should('have.text',datasetDescription);
+    cy.get('[data-cy="Access level-value"]').should('have.text', `${datasetType.toLowerCase()}${datasetType === 'Project' ? `: ${testProjectName}` : ''}`);
+    // Should not have the default empty text
+    cy.get('[data-cy="Location-value"]').should('not.have.text', '-');
+}
+
+function deleteDatasetFile (datasetType: string) {
+    const datasetName = generateDatasetName(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click details
+    clickAndAction('details');
+    cy.wait(2000);
+
+    // Filter for the uploaded file
+    const datasetBrowserTableWrapper = createWrapper().findTable('[data-cy="Dataset Browser"]');
+    cy.setValueCloudscapeInput('Filter files', 'test_upload_file.txt');
+    cy.get(datasetBrowserTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
+    cy.contains('Delete').click();
+    cy.get('[data-cy="modal-delete"]').click();
+    cy.contains('No Entries exist');
+}
+
+function updateDataset (datasetType: string) {
+    const datasetName = generateDatasetName(datasetType);
+    const datasetDescription = generateDatasetDescription(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click edit
+    clickAndAction('edit');
+
+    // Check that expected values are available
+    cy.get(createWrapper().findInput('[data-cy="dataset-type"]').findNativeInput().toSelector()).should('have.value', datasetType.toLowerCase());
+    cy.get(createWrapper().findInput('[data-cy="dataset-owner"]').findNativeInput().toSelector()).should('have.value', DEFAULT_USERNAME);
+    cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).should('have.value', datasetDescription);
+
+    // Update description
+    cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).type(' Updated');
+
+    // Save description change
+    cy.contains('Update dataset').scrollIntoView().click();
+
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    clickAndAction('details');
+
+    cy.get('[data-cy="Description-value"]').should('have.text', `${datasetDescription} Updated`);
+
+    uploadFile('test_second_upload_file.txt');
+}
+
+function deleteDataset (datasetType: string) {
+    const datasetName = generateDatasetName(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click delete
+    clickAndAction('delete');
+    cy.get('[data-cy="modal-delete"]').click();
+
+    // Check that the dataset is deleted
+    cy.contains('0 matches');
+}
+
+// === Helper Functions ===
+function filterDatasets (datasetName: string) {
+    // Verify dataset was created
+    // Filter for the item so that it is the only one in the list
+    cy.setValueCloudscapeInput('Filter Dataset', datasetName);
+    cy.contains('1 match');
+}
+
+function uploadFile (fileName: string) {
+    // Upload a new file
+    cy.get('[data-cy="dataset-file-upload-input-Upload Files"]').as('fileInput');
+    cy.fixture('test_upload_file.txt').then((fileContent) => {
+        cy.get('@fileInput').attachFile({
+            fileContent: fileContent.toString(),
+            fileName: fileName,
+            mimeType: 'text/plain'
+        });
+    });
+    // Verify file was added
+    cy.contains(fileName);
+}
+
+function clickDataset () {
+    const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');        
+    // Click on the first item's selection box
+    cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
+}
+
+function clickAndAction (action: string) {
+    // Click the actions dropdown and click the provided action button
+    const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
+    cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
+    cy.get(actionsDropdownWrapper.findItemById(action).toSelector()).click();
+}
+
+function generateDatasetName (datasetType: string) {
+    return `e2eTest${datasetType}Dataset${testTime}`;
+}
+
+function generateDatasetDescription (datasetType: string) {
+    return `${datasetType} dataset test`;
+}


### PR DESCRIPTION
*Description of changes:* Did a pretty major refactor of the dataset tests code so that it could be easily re-used for datasets other than just Global.

Currently these tests will comprehensively cover functionality for datasets of type:
* Global
* Private
* Project

This PR does *not* cover Group datasets, those will be covered in a later PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
