### PR TITLE
Group Dataset tests

### DIFF
--- a/backend/src/ml_space_lambda/dataset/lambda_functions.py
+++ b/backend/src/ml_space_lambda/dataset/lambda_functions.py
@@ -247,7 +247,7 @@ def create_dataset(event, context):
         body = json.loads(event["body"])
         dataset_type = body.get("datasetType")
         dataset_name = body.get("datasetName")
-        groups = body.get("datasetGroups", [])
+        groups = []
         env_variables = get_environment_variables()
 
         if dataset_type == DatasetType.GLOBAL:
@@ -255,6 +255,7 @@ def create_dataset(event, context):
             dataset_scope = scope
             directory_name = f"global/datasets/{dataset_name}/"
         elif dataset_type == DatasetType.GROUP:
+            groups = body.get("datasetGroups", [])
             scope = ",".join(groups)
             dataset_scope = DatasetType.GROUP
             directory_name = f"group/datasets/{dataset_name}/"
@@ -275,6 +276,7 @@ def create_dataset(event, context):
                 description=body.get("datasetDescription", ""),
                 location=dataset_location,
                 created_by=event["requestContext"]["authorizer"]["principalId"],
+                groups=groups,
             )
             # For groups, create one entry per group that shares this dataset
             if dataset_type == DatasetType.GROUP:

--- a/backend/test/dataset/test_create_dataset.py
+++ b/backend/test/dataset/test_create_dataset.py
@@ -62,6 +62,7 @@ def generate_dataset_model(event: dict, scope: str, dataset_location: str, type:
         description=body.get("datasetDescription", ""),
         location=dataset_location,
         created_by=event["requestContext"]["authorizer"]["principalId"],
+        groups=body.get("datasetGroups") if type == DatasetType.GROUP else [],
     )
 
 

--- a/cypress/cypress/e2e/datasets.spec.cy.ts
+++ b/cypress/cypress/e2e/datasets.spec.cy.ts
@@ -14,7 +14,6 @@
   limitations under the License.
 */
 
-import { dataset } from './resources';
 import {
     BASE_URL,
     DEFAULT_USERNAME,
@@ -23,12 +22,11 @@ import {
 import createWrapper from '@cloudscape-design/components/test-utils/selectors';
 import { TestProps } from '../support/test-initializer/types';
 
+const testTime = new Date().getTime();
+
 describe('Dataset Tests', () => {
-    const testTime = new Date().getTime();
     const testProjectPrefix = 'Datasets';
     const testProjectName = `${testProjectPrefix}${testTime}`;
-    const datasetName = `e2eTestDataset${testTime}`;
-    const testDataset = { ...dataset, DatasetName: `${datasetName}`, ProjectName: `${testProjectName}` };
 
     const testProps: TestProps = {
         login: true,
@@ -56,151 +54,231 @@ describe('Dataset Tests', () => {
         cy.teardownTest(testProps);
     });
 
-    it('Create Dataset', () => {
-        cy.contains('Create dataset').click();
-        cy.url().should('include', '/dataset/create');
+    // === Global ===
 
-        // Set dataset values
-        cy.setValueCloudscapeInput('dataset-name-input', datasetName);
-        cy.setValueCloudscapeTextArea('dataset-description-textarea', testDataset.DatasetDescription);
-        cy.setValueCloudscapeSelect('dataset-type-select', testDataset.DatasetType.toLocaleLowerCase());
-        cy.get('[data-cy="dataset-file-upload-input-Upload Files"]').as('fileInput');
-        cy.fixture('test_upload_file.txt').then((fileContent) => {
-            cy.get('@fileInput').attachFile({
-                fileContent: fileContent.toString(),
-                fileName: 'test_upload_file.txt',
-                mimeType: testDataset.DatasetFormat
-            });
-        });
-
-        // Verify expected values were input and retained by the form
-        cy.verifyCloudscapeInput('dataset-name-input', datasetName);
-        cy.verifyCloudscapeTextArea('dataset-description-textarea', testDataset.DatasetDescription);
-        cy.verifyCloudscapeSelect('dataset-type-select', testDataset.DatasetType);
-        cy.get('[data-cy="dataset-submit-button"]').click();
-        cy.wait(2000);
-        
-        // Verify dataset creation redirected to main dataset page
-        cy.url().should('include', `#/project/${testProjectName}/dataset`).should('include', datasetName);
-
-        // Wait for the dataset to be populated and redirect to the datasets page
-        // Occasional failures to load were observed at 5000ms wait time in development
-        cy.visit(`${BASE_URL}#/project/${testProjectName}/dataset`);
-        cy.wait(2000);
-        cy.reload();
-
-        // Verify dataset was created
-        // Filter for the item so that it is the only one in the list
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
+    it('Create Global Dataset', () => {
+        createDataset('Global', testProjectName);
     });
 
-    it('Dataset Details', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Arbitrary wait for DOM to stabilize
-        cy.wait(1000);
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).click();
-
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).click();
-        cy.get(actionsDropdownWrapper.findItemById('details').toSelector()).click();
-
-        cy.get('[data-cy="Name-value"]').should('have.text', testDataset.DatasetName);
-        cy.get('[data-cy="Description-value"]').should('have.text', testDataset.DatasetDescription);
-        cy.get('[data-cy="Access level-value"]').should('have.text', testDataset.DatasetType.toLowerCase());
-        // Should not have the default empty text
-        cy.get('[data-cy="Location-value"]').should('not.have.text', '-');
+    it('Global Dataset Details', () => {
+        getDatasetDetails('Global');
     });
 
-    it('Delete Dataset File', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.findItemById('details').toSelector()).scrollIntoView().click();
-        cy.wait(2000);
-
-        // Filter for the uploaded file
-        const datasetBrowserTableWrapper = createWrapper().findTable('[data-cy="Dataset Browser"]');
-        cy.setValueCloudscapeInput('Filter files', 'test_upload_file.txt');
-        cy.get(datasetBrowserTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-        cy.contains('Delete').click();
-        cy.get('[data-cy="modal-delete"]').click();
-        cy.contains('No Entries exist');
+    it('Delete Global Dataset File', () => {
+        deleteDatasetFile('Global');
     });
 
-    it('Update Dataset', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.findItemById('edit').toSelector()).click();
-
-        // Check that expected values are available
-        cy.get(createWrapper().findInput('[data-cy="dataset-type"]').findNativeInput().toSelector()).should('have.value', testDataset.DatasetType.toLowerCase());
-        cy.get(createWrapper().findInput('[data-cy="dataset-owner"]').findNativeInput().toSelector()).should('have.value', DEFAULT_USERNAME);
-        cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).should('have.value', testDataset.DatasetDescription);
-
-        // Update description
-        cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).type(' Updated');
-
-        // Save description change
-        cy.contains('Update dataset').scrollIntoView().click();
-
-        // Saving the change redirects back to the dataset table
-        // Verify the description is updated in the table
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.toSelector()).click();
-        cy.get(actionsDropdownWrapper.findItemById('details').toSelector()).click();
-        cy.get('[data-cy="Description-value"]').should('have.text', `${testDataset.DatasetDescription} Updated`);
-
-        // Upload a new file
-        cy.get('[data-cy="dataset-file-upload-input-Upload Files"]').as('fileInput');
-        cy.fixture('test_upload_file.txt').then((fileContent) => {
-            cy.get('@fileInput').attachFile({
-                fileContent: fileContent.toString(),
-                fileName: 'test_second_upload_file.txt',
-                mimeType: testDataset.DatasetFormat
-            });
-        });
-        // Verify file was added
-        cy.contains('test_second_upload_file.txt');
+    it('Update Global Dataset', () => {
+        updateDataset('Global');
     });
 
-    it('Delete Dataset', () => {
-        // Filter for the item so it is the only one in the list
-        const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');
-        cy.setValueCloudscapeInput('Filter Dataset', datasetName);
-        cy.contains('1 match');
-        // Click on the first item's selection box
-        cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
+    it('Delete Global Dataset', () => {
+        deleteDataset('Global');
+    });
 
-        // Click the actions dropdown and click edit
-        const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
-        cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
-        cy.get(actionsDropdownWrapper.findItemById('delete').toSelector()).click();
-        cy.get('[data-cy="modal-delete"]').click();
+    // === Private ===
 
-        // Check that the dataset is deleted
-        cy.contains('0 matches');
+    it('Create Private Dataset', () => {
+        createDataset('Private', testProjectName);
+    });
+
+    it('Private Dataset Details', () => {
+        getDatasetDetails('Private');
+    });
+
+    it('Delete Private Dataset File', () => {
+        deleteDatasetFile('Private');
+    });
+
+    it('Update Private Dataset', () => {
+        updateDataset('Private');
+    });
+
+    it('Delete Private Dataset', () => {
+        deleteDataset('Private');
+    });
+
+    // === Project ===
+
+    it('Create Project Dataset', () => {
+        createDataset('Project', testProjectName);
+    });
+
+    it('Project Dataset Details', () => {
+        getDatasetDetails('Project', testProjectName);
+    });
+
+    it('Delete Project Dataset File', () => {
+        deleteDatasetFile('Project');
+    });
+
+    it('Update Project Dataset', () => {
+        updateDataset('Project');
+    });
+
+    it('Delete Project Dataset', () => {
+        deleteDataset('Project');
     });
 });
+
+// === Driver Functions ===
+function createDataset (datasetType: string, testProjectName: string) {
+    const datasetName = generateDatasetName(datasetType);
+    const datasetDescription = generateDatasetDescription(datasetType);
+    cy.contains('Create dataset').click();
+    cy.url().should('include', '/dataset/create');
+
+    // Set dataset values
+    cy.setValueCloudscapeInput('dataset-name-input', datasetName);
+    cy.setValueCloudscapeTextArea('dataset-description-textarea', datasetDescription);
+    cy.setValueCloudscapeSelect('dataset-type-select', datasetType.toLocaleLowerCase());
+
+    uploadFile('test_upload_file.txt');
+
+    // Verify expected values were input and retained by the form
+    cy.verifyCloudscapeInput('dataset-name-input', datasetName);
+    cy.verifyCloudscapeTextArea('dataset-description-textarea', datasetDescription);
+    cy.verifyCloudscapeSelect('dataset-type-select', datasetType);
+    cy.get('[data-cy="dataset-submit-button"]').click();
+    cy.wait(2000);
+    
+    // Verify dataset creation redirected to main dataset page
+    cy.url().should('include', `#/project/${testProjectName}/dataset`).should('include', datasetName);
+
+    // Wait for the dataset to be populated and redirect to the datasets page
+    // Occasional failures to load were observed at 5000ms wait time in development
+    cy.visit(`${BASE_URL}#/project/${testProjectName}/dataset`);
+    cy.wait(2000);
+    cy.reload();
+
+    filterDatasets(datasetName);
+}
+
+function getDatasetDetails (datasetType: string, testProjectName?: string) {
+    const datasetName = generateDatasetName(datasetType);
+    const datasetDescription = generateDatasetDescription(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click edit
+    clickAndAction('details');
+
+    cy.get('[data-cy="Name-value"]').should('have.text', datasetName);
+    cy.get('[data-cy="Description-value"]').should('have.text',datasetDescription);
+    cy.get('[data-cy="Access level-value"]').should('have.text', `${datasetType.toLowerCase()}${datasetType === 'Project' ? `: ${testProjectName}` : ''}`);
+    // Should not have the default empty text
+    cy.get('[data-cy="Location-value"]').should('not.have.text', '-');
+}
+
+function deleteDatasetFile (datasetType: string) {
+    const datasetName = generateDatasetName(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click details
+    clickAndAction('details');
+    cy.wait(2000);
+
+    // Filter for the uploaded file
+    const datasetBrowserTableWrapper = createWrapper().findTable('[data-cy="Dataset Browser"]');
+    cy.setValueCloudscapeInput('Filter files', 'test_upload_file.txt');
+    cy.get(datasetBrowserTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
+    cy.contains('Delete').click();
+    cy.get('[data-cy="modal-delete"]').click();
+    cy.contains('No Entries exist');
+}
+
+function updateDataset (datasetType: string) {
+    const datasetName = generateDatasetName(datasetType);
+    const datasetDescription = generateDatasetDescription(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click edit
+    clickAndAction('edit');
+
+    // Check that expected values are available
+    cy.get(createWrapper().findInput('[data-cy="dataset-type"]').findNativeInput().toSelector()).should('have.value', datasetType.toLowerCase());
+    cy.get(createWrapper().findInput('[data-cy="dataset-owner"]').findNativeInput().toSelector()).should('have.value', DEFAULT_USERNAME);
+    cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).should('have.value', datasetDescription);
+
+    // Update description
+    cy.get(createWrapper().findTextarea('[data-cy="dataset-description"]').findNativeTextarea().toSelector()).type(' Updated');
+
+    // Save description change
+    cy.contains('Update dataset').scrollIntoView().click();
+
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    clickAndAction('details');
+
+    cy.get('[data-cy="Description-value"]').should('have.text', `${datasetDescription} Updated`);
+
+    uploadFile('test_second_upload_file.txt');
+}
+
+function deleteDataset (datasetType: string) {
+    const datasetName = generateDatasetName(datasetType);
+    // Filter for the item so it is the only one in the list
+    filterDatasets(datasetName);
+
+    clickDataset();
+
+    // Click the actions dropdown and click delete
+    clickAndAction('delete');
+    cy.get('[data-cy="modal-delete"]').click();
+
+    // Check that the dataset is deleted
+    cy.contains('0 matches');
+}
+
+// === Helper Functions ===
+function filterDatasets (datasetName: string) {
+    // Verify dataset was created
+    // Filter for the item so that it is the only one in the list
+    cy.setValueCloudscapeInput('Filter Dataset', datasetName);
+    cy.contains('1 match');
+}
+
+function uploadFile (fileName: string) {
+    // Upload a new file
+    cy.get('[data-cy="dataset-file-upload-input-Upload Files"]').as('fileInput');
+    cy.fixture('test_upload_file.txt').then((fileContent) => {
+        cy.get('@fileInput').attachFile({
+            fileContent: fileContent.toString(),
+            fileName: fileName,
+            mimeType: 'text/plain'
+        });
+    });
+    // Verify file was added
+    cy.contains(fileName);
+}
+
+function clickDataset () {
+    const datasetsTableWrapper = createWrapper().findTable('[data-cy="Dataset-table"]');        
+    // Click on the first item's selection box
+    cy.get(datasetsTableWrapper.findRowSelectionArea(1).toSelector()).scrollIntoView().click();
+}
+
+function clickAndAction (action: string) {
+    // Click the actions dropdown and click the provided action button
+    const actionsDropdownWrapper = createWrapper().findButtonDropdown('[data-cy="dataset-actions-dropdown"]');
+    cy.get(actionsDropdownWrapper.toSelector()).scrollIntoView().click();
+    cy.get(actionsDropdownWrapper.findItemById(action).toSelector()).click();
+}
+
+function generateDatasetName (datasetType: string) {
+    return `e2eTest${datasetType}Dataset${testTime}`;
+}
+
+function generateDatasetDescription (datasetType: string) {
+    return `${datasetType} dataset test`;
+}

--- a/cypress/cypress/e2e/datasets.spec.cy.ts
+++ b/cypress/cypress/e2e/datasets.spec.cy.ts
@@ -22,18 +22,23 @@ import {
 import createWrapper from '@cloudscape-design/components/test-utils/selectors';
 import { TestProps } from '../support/test-initializer/types';
 
+const testPrefix = 'Datasets';
 const testTime = new Date().getTime();
+const testProjectName = `${testPrefix}${testTime}`;
 
 describe('Dataset Tests', () => {
-    const testProjectPrefix = 'Datasets';
-    const testProjectName = `${testProjectPrefix}${testTime}`;
+    const testGroupName = `Group${testTime}`;
 
     const testProps: TestProps = {
         login: true,
-        projectPrefix: testProjectPrefix,
+        projectPrefix: testPrefix,
         projects: [{
-            name: `${testProjectPrefix}${testTime}`,
-            description: `Test project used for testing ${testProjectPrefix}`
+            name: testProjectName,
+            description: `Test project used for testing ${testPrefix}`
+        }],
+        groups: [{
+            name: testGroupName,
+            description: `Test group used for testing ${testPrefix}`
         }],
     };
 
@@ -119,10 +124,32 @@ describe('Dataset Tests', () => {
     it('Delete Project Dataset', () => {
         deleteDataset('Project');
     });
+
+    // === Group ===
+
+    it('Create Group Dataset', () => {
+        createDataset('Group', testGroupName);
+    });
+
+    it('Group Dataset Details', () => {
+        getDatasetDetails('Group', testGroupName);
+    });
+
+    it('Delete Group Dataset File', () => {
+        deleteDatasetFile('Group');
+    });
+
+    it('Update Group Dataset', () => {
+        updateDataset('Group');
+    });
+
+    it('Delete Group Dataset', () => {
+        deleteDataset('Group');
+    });
 });
 
 // === Driver Functions ===
-function createDataset (datasetType: string, testProjectName: string) {
+function createDataset (datasetType: string, testName: string) {
     const datasetName = generateDatasetName(datasetType);
     const datasetDescription = generateDatasetDescription(datasetType);
     cy.contains('Create dataset').click();
@@ -139,8 +166,15 @@ function createDataset (datasetType: string, testProjectName: string) {
     cy.verifyCloudscapeInput('dataset-name-input', datasetName);
     cy.verifyCloudscapeTextArea('dataset-description-textarea', datasetDescription);
     cy.verifyCloudscapeSelect('dataset-type-select', datasetType);
+
+    if (datasetType === 'Group') {
+        cy.setValueCloudscapeMultiselect('group-name-multiselect', [testName]);
+    }
+    
+
+
     cy.get('[data-cy="dataset-submit-button"]').click();
-    cy.wait(2000);
+    cy.wait(3000);
     
     // Verify dataset creation redirected to main dataset page
     cy.url().should('include', `#/project/${testProjectName}/dataset`).should('include', datasetName);
@@ -154,7 +188,7 @@ function createDataset (datasetType: string, testProjectName: string) {
     filterDatasets(datasetName);
 }
 
-function getDatasetDetails (datasetType: string, testProjectName?: string) {
+function getDatasetDetails (datasetType: string, testName?: string) {
     const datasetName = generateDatasetName(datasetType);
     const datasetDescription = generateDatasetDescription(datasetType);
     // Filter for the item so it is the only one in the list
@@ -167,7 +201,7 @@ function getDatasetDetails (datasetType: string, testProjectName?: string) {
 
     cy.get('[data-cy="Name-value"]').should('have.text', datasetName);
     cy.get('[data-cy="Description-value"]').should('have.text',datasetDescription);
-    cy.get('[data-cy="Access level-value"]').should('have.text', `${datasetType.toLowerCase()}${datasetType === 'Project' ? `: ${testProjectName}` : ''}`);
+    cy.get('[data-cy="Access level-value"]').should('have.text', `${datasetType.toLowerCase()}${datasetType === 'Project' ? `: ${testName}` : ''}`);
     // Should not have the default empty text
     cy.get('[data-cy="Location-value"]').should('not.have.text', '-');
 }
@@ -235,6 +269,8 @@ function deleteDataset (datasetType: string) {
     // Click the actions dropdown and click delete
     clickAndAction('delete');
     cy.get('[data-cy="modal-delete"]').click();
+    cy.intercept('GET', '**/datasets').as('getDatasets');
+    cy.wait('@getDatasets', { timeout: 10000 });
 
     // Check that the dataset is deleted
     cy.contains('0 matches');

--- a/cypress/cypress/e2e/project.spec.cy.ts
+++ b/cypress/cypress/e2e/project.spec.cy.ts
@@ -44,6 +44,9 @@ describe('Project Tests', () => {
 
 
         cy.get('[data-cy="submit"]').click();
+        cy.intercept('GET', `**/project/${name}**`).as('getProject');
+        cy.wait('@getProject', { timeout: 10000 });
+
         cy.url().should('include', `/project/${testProjectName}`);
         cy.contains(testProjectName);
     });

--- a/cypress/cypress/global.d.ts
+++ b/cypress/cypress/global.d.ts
@@ -41,5 +41,7 @@ declare namespace Cypress {
         deleteProjectsWithPrefix(projectPrefix: string): Chainable<Response>;
         createDataset(props: DatasetProps): Chainable<Response>;
         deleteDataset(datasetName: string): Chainable<Response>;
+        createGroup(props: GroupProps): Chainable<Response>;
+        deleteGroup(groupName: string): Chainable<Response>;
     };
 }

--- a/cypress/cypress/support/cloudscape-utils/utils.ts
+++ b/cypress/cypress/support/cloudscape-utils/utils.ts
@@ -58,7 +58,7 @@ export const setValueCloudscapeTile = (dataSelector: string, value: string): voi
 };
 
 export const dismissNotification = (notificationText: string): void => {
-    cy.contains(notificationText).get('[aria-label="Dismiss notification"]').click();
+    cy.contains(notificationText).get(`[aria-label="Dismiss notification ${notificationText}"]`).click();
 };
 
 Cypress.Commands.add('setValueCloudscapeInput', (dataSelector: string, value: string) => {

--- a/cypress/cypress/support/commands.ts
+++ b/cypress/cypress/support/commands.ts
@@ -22,6 +22,7 @@ import './cloudscape-utils/test-utils';
 import './test-initializer/init';
 import './project-commands/project';
 import './dataset-commands/dataset';
+import './group-commands/group';
 import './table-commands/table';
 import 'cypress-file-upload';
 import { AuthType } from './test-initializer/types';

--- a/cypress/cypress/support/group-commands/group.ts
+++ b/cypress/cypress/support/group-commands/group.ts
@@ -1,0 +1,59 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { dismissNotification } from '../cloudscape-utils/utils';
+import { GroupProps } from '../test-initializer/types';
+import { BASE_URL } from '../commands';
+
+const createGroup = ({ name, description }: GroupProps) => {
+    cy.intercept('GET', `**/group/${name}**`).as('getGroup');
+
+    cy.visit(`${BASE_URL}#/personal/group`);
+    cy.contains('Create Group').click();
+    cy.url().should('include', '/groups/create');
+
+    cy.setValueCloudscapeInput('name-input', name);
+    cy.setValueCloudscapeTextArea('description-input', description);
+
+    // Verify that the values have been updated
+    cy.verifyCloudscapeInput('name-input', name);
+    cy.verifyCloudscapeTextArea('description-input', description);
+
+    cy.get('[data-cy="submit"]').click();
+    cy.wait('@getGroup', { timeout: 10000 });
+    cy.url().should('include', `/groups/${name}`);
+    dismissNotification(`Successfully created group ${name}`);
+    dismissNotification(`Users added to group: ${name}.`);
+};
+
+const deleteGroup = (groupName: string) => {
+    cy.visit(`${BASE_URL}#/admin/groups/${groupName}`);
+    cy.contains('Actions').click();
+    cy.contains('Delete').click();
+    cy.contains(`Delete "${groupName}"?`);
+    cy.get('[data-cy="modal-delete"]').click();
+    cy.contains(`Group ${groupName} deleted.`);
+    cy.url().should('not.include', `groups/${groupName}`);
+};
+
+Cypress.Commands.add('createGroup', (props: GroupProps) => {
+    return createGroup(props);
+});
+
+Cypress.Commands.add('deleteGroup', (groupName: string) => {
+    return deleteGroup(groupName);
+});
+

--- a/cypress/cypress/support/project-commands/project.ts
+++ b/cypress/cypress/support/project-commands/project.ts
@@ -29,7 +29,7 @@ const createProject = ({ name, description }: ProjectProps) => {
     cy.verifyCloudscapeInput('name-input', name);
     cy.verifyCloudscapeTextArea('description-input', description);
     cy.get('[data-cy="submit"]').click();
-    cy.wait('@getProject');
+    cy.wait('@getProject', { timeout: 10000 });
     cy.url().should('include', `/project/${name}`);
     dismissNotification(`Successfully created project ${name}`);
 };
@@ -77,7 +77,7 @@ const deleteProjectsWithPrefix = (projectNamePrefix: string, maxNumberOfDeletes 
 
                 for (let i = 0; i < allProjects.length; i++) {
                     const project = allProjects[i];
-                    if (project.name.startsWith(projectNamePrefix)) {
+                    if (project.name && project.name.startsWith(projectNamePrefix)) {
                         deleteProject(project.name);
 
                         if (++numberDeleted >= maxNumberOfDeletes) {

--- a/cypress/cypress/support/test-initializer/init.ts
+++ b/cypress/cypress/support/test-initializer/init.ts
@@ -21,7 +21,7 @@ let resizerErrorIframeClosed = false;
 
 const initializeTest = (props: TestProps) => {
     Cypress.session.clearAllSavedSessions();
-    const { login, projects, datasets, projectPrefix } = props;
+    const { login, projects, datasets, projectPrefix, groups } = props;
     if (login) {
         if (AUTH_TYPE === AuthType.Cognito) {
             cy.loginByCognito(
@@ -48,6 +48,9 @@ const initializeTest = (props: TestProps) => {
     datasets?.forEach((dataset) => {
         cy.createDataset(dataset);
     });
+    groups?.forEach((group) => {
+        cy.createGroup(group);
+    });
 
     const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
     Cypress.on('uncaught:exception', (err) => {
@@ -63,12 +66,15 @@ const initializeTest = (props: TestProps) => {
 };
 
 const teardownTest = (props: TestProps) => {
-    const { projects, datasets } = props;
+    const { projects, datasets, groups } = props;
     datasets?.forEach((dataset) => {
         cy.deleteDataset(dataset.name);
     });
     projects?.forEach((project) => {
         cy.deleteProject(project.name);
+    });
+    groups?.forEach((group) => {
+        cy.deleteGroup(group.name);
     });
 };
 

--- a/cypress/cypress/support/test-initializer/types.ts
+++ b/cypress/cypress/support/test-initializer/types.ts
@@ -32,12 +32,17 @@ type DatasetProps = {
     files: string[];
 };
 
+type GroupProps = {
+    name: string;
+    description: string;
+};
 
 type TestProps = {
     projectPrefix?: string;
     login?: boolean;
     projects?: ProjectProps[];
     datasets?: DatasetProps[];
+    groups?: GroupProps[];
 };
 
-export { ProjectProps, DatasetProps, TestProps, AuthType };
+export { ProjectProps, DatasetProps, GroupProps, TestProps, AuthType };

--- a/frontend/src/entities/configuration/deployment-configuration.tsx
+++ b/frontend/src/entities/configuration/deployment-configuration.tsx
@@ -164,6 +164,7 @@ export function DeploymentConfiguration () {
                                     filteringType='auto'
                                     placeholder='Choose options'
                                     selectedAriaLabel='Selected'
+                                    data-cy='deployment-config-multiselect'
                                 />
                             </FormField>
                             <Button

--- a/frontend/src/entities/configuration/emr-configuration.tsx
+++ b/frontend/src/entities/configuration/emr-configuration.tsx
@@ -108,6 +108,7 @@ export function EmrConfiguration (props: EmrConfigurationProps) {
                     }
                     options={applicationOptions}
                     placeholder='Select applications'
+                    data-cy='emr-config-multiselect'
                 />
             </ExpandableSection>
             <ExpandableSection

--- a/frontend/src/entities/group/create/group-create.tsx
+++ b/frontend/src/entities/group/create/group-create.tsx
@@ -37,7 +37,7 @@ import { addUserVisibleColumns, userColumns } from '../../user/user.columns';
 import Table from '../../../modules/table';
 import { IUser } from '../../../shared/model/user.model';
 import { addUsersToGroup } from '../user/group-user-functions';
-import { getAllUsers } from '../../user/user.reducer';
+import { getAllUsers, selectCurrentUser } from '../../user/user.reducer';
 import { setBreadcrumbs } from '../../../shared/layout/navigation/navigation.reducer';
 import { getBase } from '../../../shared/util/breadcrumb-utils';
 import { scrollToPageHeader } from '../../../shared/doc';
@@ -53,7 +53,9 @@ export function GroupCreate ({isEdit}: GroupCreateProperties) {
     const {groupName} = useParams();
     const [initialLoaded, setInitialLoaded] = useState(false);
     const allUsers: IUser[] = useAppSelector((state) => state.user.allUsers);
-    const [selectedUsers, setSelectedUsers] = useState<IUser[]>([]);
+    const currentUser = useAppSelector(selectCurrentUser);
+    const [selectedUsers, setSelectedUsers] = useState<IUser[]>([currentUser]);
+    
     const baseUrl = window.location.href.includes('#/admin') ? '#/admin/groups' : '#/personal/group';
 
     useEffect(() => {
@@ -187,6 +189,7 @@ export function GroupCreate ({isEdit}: GroupCreateProperties) {
                             selectItemsCallback={(e) => {
                                 setSelectedUsers(e);
                             }}
+                            defaultSelectedItems={[currentUser]}
                             trackBy='username'
                             allItems={allUsers}
                             columnDefinitions={userColumns}

--- a/frontend/src/entities/group/detail/group-detail.actions.tsx
+++ b/frontend/src/entities/group/detail/group-detail.actions.tsx
@@ -104,7 +104,7 @@ const GroupActionHandler = (
         case 'delete_group':
             dispatch(
                 setDeleteModal({
-                    resourceName: 'Group',
+                    resourceName: groupName,
                     resourceType: 'group',
                     postConfirm: () => dispatch(getAllGroups(window.location.href.includes('#/admin'))),
                     onConfirm: async () =>

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/hyperparameters.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/hyperparameters.tsx
@@ -551,6 +551,7 @@ export function HyperParameterFieldValue (props: HyperParameterFieldValueProps) 
                             touchFields([`hyperparameters.${item.key}`]);
                         }}
                         onBlur={() => touchFields([item.key])}
+                        data-cy='hpo-value-multiselect'
                     />
                 );
             } else {
@@ -664,6 +665,7 @@ export function HyperParameterFieldValue (props: HyperParameterFieldValueProps) 
                         updateParameter(item);
                         touchFields([`hyperparameters.${item.key}`]);
                     }}
+                    data-cy='hpo-categorical-multiselect'
                 />
             );
         }

--- a/frontend/src/entities/jobs/hpo/create/training-definitions/network-settings.tsx
+++ b/frontend/src/entities/jobs/hpo/create/training-definitions/network-settings.tsx
@@ -82,6 +82,7 @@ export function NetworkSettings (props: FormProps<ITrainingJobDefinition>) {
                         };
                     })}
                     placeholder='Choose options'
+                    data-cy='network-settings-multiselect'
                 />
             </FormField>
         </ExpandableSection>

--- a/frontend/src/entities/jobs/hyperparameter-field.tsx
+++ b/frontend/src/entities/jobs/hyperparameter-field.tsx
@@ -38,6 +38,7 @@ export function HyperparameterField (props: HyperparameterFieldProps) {
                         setFields(toUpdate);
                     }}
                     onBlur={() => touchFields([item.key])}
+                    data-cy='hpo-field-multiselect'
                 />
             );
         } else {

--- a/frontend/src/entities/report/report.tsx
+++ b/frontend/src/entities/report/report.tsx
@@ -233,6 +233,7 @@ export function Report () {
                                     filteringType='auto'
                                     placeholder='Choose options'
                                     selectedAriaLabel='Selected'
+                                    data-cy='report-multiselect'
                                 />
                             </FormField>
                         </SpaceBetween>

--- a/frontend/src/modules/table/table.tsx
+++ b/frontend/src/modules/table/table.tsx
@@ -45,6 +45,7 @@ export default function Table ({
     tableType,
     actions,
     selectItemsCallback,
+    defaultSelectedItems,
     allItems,
     setItemsOverride,
     columnDefinitions,
@@ -92,7 +93,11 @@ export default function Table ({
             },
             pagination: { pageSize: preferences.pageSize },
             sorting: {},
-            selection: {keepSelection},
+            selection: {
+                defaultSelectedItems: defaultSelectedItems,
+                keepSelection,
+                
+            },
         });
 
     const { selectedItems } = collectionProps;
@@ -174,6 +179,7 @@ export default function Table ({
 
     return (
         <CloudscapeTable
+            selectedItems={selectedItems}
             data-cy={`${tableName}-table`}
             {...collectionProps}
             onSelectionChange={(event) => {

--- a/frontend/src/modules/table/table.types.tsx
+++ b/frontend/src/modules/table/table.types.tsx
@@ -30,6 +30,7 @@ type TableProps<Entry = TableEntry> = {
     tableType?: CloudscapeTableProps.SelectionType;
     actions?: CallbackFunction<TableActionProps<Entry>, ReactNode | undefined>;
     selectItemsCallback?: CallbackFunction<Entry[]>;
+    defaultSelectedItems?: any[],
     allItems: Entry[];
     setItemsOverride?: CallbackFunction;
     columnDefinitions: CloudscapeTableProps.ColumnDefinition<Entry>[];

--- a/frontend/src/shared/layout/notification/notification.service.tsx
+++ b/frontend/src/shared/layout/notification/notification.service.tsx
@@ -34,7 +34,7 @@ function NotificationService (dispatch: ThunkDispatch<any, any, Action>) {
         return {
             ...props,
             onDismiss: () => dispatch(clearNotification(props.id)),
-            dismissLabel: 'Dismiss notification',
+            dismissLabel: `Dismiss notification ${props.header}`,
         } as FlashbarProps.MessageDefinition;
     }
 


### PR DESCRIPTION
*Description of changes:* Tests added for testing the creation of Group datasets.

These changes include:
* support code for the creation and deletion of a Group for testing
* tests for the CRUD operations of Group Datasets
* several improvements to the consistency of tests by leveraging intercept-waits rather than hardcoded waits (so instead of guessing how long an API call should take we can just wait for it to be fulfilled)
* adding/updating aria-labels, data-cy labels, etc so that tests can find the correct elements in the UI
* fixed some bugs like: the list of groups associated with a group dataset not being populated and the Group deletion modal not displaying the actual Group name

All e2e tests are now consistently passing and all unit tests are passing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
