### PR TITLE
e2e test to activate/deactivate service

### DIFF
--- a/cypress/cypress/e2e/app-config.spec.cy.ts
+++ b/cypress/cypress/e2e/app-config.spec.cy.ts
@@ -1,0 +1,94 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License").
+  You may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import {
+    BASE_URL,
+    login,
+} from '../support/commands';
+import { TestProps } from '../support/test-initializer/types';
+
+const testPrefix = 'AppConfig';
+const testTime = new Date().getTime();
+const testProjectName = `${testPrefix}${testTime}`;
+
+describe('Dataset Tests', () => {
+
+    const testProps: TestProps = {
+        login: true,
+        projectPrefix: testPrefix,
+        projects: [{
+            name: testProjectName,
+            description: `Test project used for testing ${testPrefix}`
+        }],
+    };
+
+    before(() => {
+        cy.initializeTest(testProps);
+    });
+
+    beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
+        // Call login routine
+        login();
+        // Navigate to app config page
+        cy.visit(`${BASE_URL}#/admin/configuration`);
+        cy.url().should('include', '#/admin/configuration');
+    });
+
+    after(async () => {
+        cy.teardownTest(testProps);
+    });
+
+    // it('Disable Instance Type - Notebook', () => {
+    //     cy.get('[data-cy="Notebook-Expandable-Section"]').click();
+    //     // TODO: Section is expanding fine but now we can't find the item in the multiselect
+    //     cy.setValueCloudscapeMultiselect('instance-type-multi-select-InstanceType', ['ml.t2.medium']);
+    //     cy.get('[data-cy="dynamic-configuration-submit"]').click();
+    //     cy.get('[data-cy="config-submit-button"]').click();
+    //     cy.intercept('POST', '**/app-config').as('updateConfig');
+    //     cy.wait('@updateConfig', { timeout: 10000 });
+    // });
+
+    // it('Enable Instance Type - Notebook', () => {
+    //     //TODO
+    // });
+
+    it('Deactivate Service - GroundTruth', () => {
+        cy.intercept('POST', '**/app-config').as('updateConfig');
+        cy.get('[data-cy="Toggle-labelingJob"]').click();
+        cy.get('[data-cy="dynamic-configuration-submit"]').click();
+
+        cy.get('[data-cy="config-submit-button"]').click();
+
+        
+        cy.wait('@updateConfig', { timeout: 10000 });
+        cy.visit(`${BASE_URL}#/project/${testProjectName}/jobs/labeling`);
+        cy.contains('Not Found');
+    });
+
+    it('Activate Service - GroundTruth', () => {
+        cy.intercept('POST', '**/app-config').as('updateConfig');
+        cy.get('[data-cy="Toggle-labelingJob"]').click();
+        cy.get('[data-cy="dynamic-configuration-submit"]').click();
+
+        cy.get('[data-cy="config-submit-button"]').click();
+
+        
+        cy.wait('@updateConfig', { timeout: 10000 });
+        cy.visit(`${BASE_URL}#/project/${testProjectName}/jobs/labeling`);
+        cy.contains('Create new labeling job');
+    });
+});

--- a/frontend/src/entities/configuration/activated-services-configuration.tsx
+++ b/frontend/src/entities/configuration/activated-services-configuration.tsx
@@ -77,6 +77,7 @@ export function ActivatedServicesConfiguration (props: ActivatedServicesConfigur
                                             props.setFields(updatedField);
                                         }}
                                         checked={props.enabledServices[service]}
+                                        data-cy={`Toggle-${service}`}
                                     >
                                     </Toggle>
                                 </SpaceBetween>

--- a/frontend/src/entities/configuration/allowed-instance-types-configuration.tsx
+++ b/frontend/src/entities/configuration/allowed-instance-types-configuration.tsx
@@ -87,7 +87,7 @@ export function AllowedInstanceTypesConfiguration (props: AllowedInstanceTypesCo
                     and will have no affect on resources created in notebooks
                 </Alert>
             }
-            <ExpandableSection headerText='Notebook instances' variant='default' expanded={props.expandedSections.notebookInstances} onChange={({ detail }) =>
+            <ExpandableSection data-cy='Notebook-Expandable-Section' headerText='Notebook instances' variant='default' expanded={props.expandedSections.notebookInstances} onChange={({ detail }) =>
                 props.setExpandedSections({...props.expandedSections, notebookInstances: detail.expanded})
             }>
                 <InstanceTypeMultiSelector

--- a/frontend/src/entities/configuration/confirm-configuration-changes-modal.tsx
+++ b/frontend/src/entities/configuration/confirm-configuration-changes-modal.tsx
@@ -128,6 +128,7 @@ export function ConfirmConfigurationChangesModal (props: ConfirmConfigurationCha
                             variant='primary'
                             loading={props.isSubmitting}
                             disabled={_.isEmpty(changesDiff)}
+                            data-cy='config-submit-button'
                             onClick={async () => {
                                 await props.submit();
                                 props.setVisible(false);


### PR DESCRIPTION
*Description of changes:* Added an e2e test for deactivating and activating a service (GroundTruth in this case).

Tests are consistently passing when I test locally.

Also I started to stub out code for modifying which instance types are enabled; run into some issues on that I won't have time to address before going on leave, so left what I had commented out so someone else can carry the torch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
