### PR TITLE
Fixed error handling for isolated regions

### DIFF
--- a/backend/src/ml_space_lambda/utils/iam_manager.py
+++ b/backend/src/ml_space_lambda/utils/iam_manager.py
@@ -186,7 +186,7 @@ class IAMManager:
                 )
             except ClientError as error:
                 # Check for unsupported operation error
-                if error.response["Error"]["Code"] == "UnsupportedOperation":
+                if error.response["Error"]["Code"] == "InvalidAction":
                     logger.info(f"Tagging policies is unsupported in this region.")
                 else:
                     raise error
@@ -280,7 +280,7 @@ class IAMManager:
                 )
             except ClientError as error:
                 # Check for unsupported operation error
-                if error.response["Error"]["Code"] == "UnsupportedOperation":
+                if error.response["Error"]["Code"] == "InvalidAction":
                     logger.info(f"Tagging policies is unsupported in this region.")
                 else:
                     raise error
@@ -564,7 +564,7 @@ class IAMManager:
                 )
             except ClientError as error:
                 # Check for unsupported operation error
-                if error.response["Error"]["Code"] == "UnsupportedOperation":
+                if error.response["Error"]["Code"] == "InvalidAction":
                     logger.info(f"Tagging policies is unsupported in this region.")
                 else:
                     raise error


### PR DESCRIPTION
- Fixed catch blocks for policy tagging in isolated regions

*Issue #, if available:*

*Description of changes:*
The wrong error `Code` was being used to catch errors in isolated regions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
