### PR TITLE
Updated notebook policy to enforce correct system tagging

### DIFF
--- a/frontend/docs/admin-guide/security/policies/notebook-policy-raw.md
+++ b/frontend/docs/admin-guide/security/policies/notebook-policy-raw.md
@@ -84,8 +84,10 @@
             "Condition": {
                 "Null": {
                     "aws:RequestTag/user": "false",
-                    "aws:RequestTag/system": "false",
                     "aws:RequestTag/project": "false"
+                }
+                "StringEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": "sagemaker:CreateEndpoint",
@@ -102,9 +104,11 @@
                 "Null": {
                     "sagemaker:VpcSubnets": "false",
                     "aws:RequestTag/user": "false",
-                    "aws:RequestTag/system": "false",
                     "aws:RequestTag/project": "false",
                     "sagemaker:VpcSecurityGroupIds": "false"
+                },
+                "StringEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": "sagemaker:CreateModel",
@@ -115,8 +119,10 @@
             "Condition": {
                 "Null": {
                     "aws:RequestTag/user": "false",
-                    "aws:RequestTag/system": "false",
                     "aws:RequestTag/project": "false"
+                },
+                "StringEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": "sagemaker:CreateLabelingJob",
@@ -127,8 +133,10 @@
             "Condition": {
                 "Null": {
                     "aws:ResourceTag/project": "false",
-                    "aws:ResourceTag/system": "false",
                     "aws:ResourceTag/user": "false"
+                },
+                "StringEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": [
@@ -181,11 +189,13 @@
             "Condition": {
                 "Null": {
                     "aws:RequestTag/user": "true",
-                    "aws:RequestTag/system": "true",
                     "aws:RequestTag/project": "true",
                     "aws:ResourceTag/user": "true",
                     "aws:ResourceTag/system": "true",
                     "aws:ResourceTag/project": "true",
+                },
+                "StringNotEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": [
@@ -224,8 +234,10 @@
             "Condition": {
                 "Null": {
                     "aws:RequestTag/user": "true",
-                    "aws:RequestTag/system": "true",
                     "aws:RequestTag/project": "true"
+                },
+                "StringNotEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": ["sagemaker:CreateEndpointConfig", "sagemaker:CreateTransformJob"],
@@ -237,9 +249,11 @@
                 "Null": {
                     "sagemaker:VpcSubnets": "true",
                     "aws:RequestTag/user": "true",
-                    "aws:RequestTag/system": "true",
                     "aws:RequestTag/project": "true",
                     "sagemaker:VpcSecurityGroupIds": "true"
+                },
+                "StringNotEqualsIgnoreCase": {
+                    "aws:RequestTag/system": "MLSpace"
                 }
             },
             "Action": [

--- a/frontend/docs/admin-guide/security/policies/notebook-policy.md
+++ b/frontend/docs/admin-guide/security/policies/notebook-policy.md
@@ -150,8 +150,10 @@ The statement includes conditions that enforce additional constraints, ensuring 
         "Condition": {
             "Null": {
                 "aws:RequestTag/user": "false",
-                "aws:RequestTag/system": "false",
                 "aws:RequestTag/project": "false"
+            },
+            "StringEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": "sagemaker:CreateEndpoint",
@@ -187,9 +189,11 @@ The statement includes conditions that enforce additional constraints, ensuring 
             "Null": {
                 "sagemaker:VpcSubnets": "false",
                 "aws:RequestTag/user": "false",
-                "aws:RequestTag/system": "false",
                 "aws:RequestTag/project": "false",
                 "sagemaker:VpcSecurityGroupIds": "false"
+            },
+            "StringEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": "sagemaker:CreateModel",
@@ -209,8 +213,10 @@ The statement includes conditions that enforce additional constraints, ensuring 
         "Condition": {
             "Null": {
                 "aws:RequestTag/user": "false",
-                "aws:RequestTag/system": "false",
                 "aws:RequestTag/project": "false"
+            },
+            "StringEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": "sagemaker:CreateLabelingJob",
@@ -229,9 +235,11 @@ The statement includes conditions that restrict access to appropriately tagged r
     {
         "Condition": {
             "Null": {
-                "aws:ResourceTag/project": "false",
-                "aws:ResourceTag/system": "false",
-                "aws:ResourceTag/user": "false"
+                "aws:RequestTag/user": "false",
+                "aws:RequestTag/project": "false"
+            },
+            "StringEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": [
@@ -322,8 +330,10 @@ The statement includes conditions that enforce additional constraints, ensuring 
         "Condition": {
             "Null": {
                 "aws:RequestTag/user": "true",
-                "aws:RequestTag/system": "true",
                 "aws:RequestTag/project": "true"
+            },
+            "StringNotEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": ["sagemaker:CreateEndpointConfig", "sagemaker:CreateTransformJob"],
@@ -345,9 +355,11 @@ The statement includes conditions that enforce additional constraints, ensuring 
             "Null": {
                 "sagemaker:VpcSubnets": "true",
                 "aws:RequestTag/user": "true",
-                "aws:RequestTag/system": "true",
                 "aws:RequestTag/project": "true",
                 "sagemaker:VpcSecurityGroupIds": "true"
+            },
+            "StringNotEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": [
@@ -374,11 +386,13 @@ The statement includes conditions that enforce additional constraints, ensuring 
         "Condition": {
             "Null": {
                 "aws:RequestTag/user": "true",
-                "aws:RequestTag/system": "true",
                 "aws:RequestTag/project": "true",
                 "aws:ResourceTag/user": "true",
                 "aws:ResourceTag/system": "true",
                 "aws:ResourceTag/project": "true",
+            },
+            "StringNotEqualsIgnoreCase": {
+                "aws:RequestTag/system": "MLSpace"
             }
         },
         "Action": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We discovered that the Notebook policy was only enforcing the presence of a system tag during resource creation, without validating its value. This PR updates the Notebook policy to require the correct value for the system tag, aligning its enforcement mechanism with the value checks already applied to the user tag in the User policy and the project tag in the Project policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
