### PR TITLE
Add VPC Endpoints for AWS Translate and EMR in MLSpace VPCs

### DIFF
--- a/bin/mlspace-cdk.ts
+++ b/bin/mlspace-cdk.ts
@@ -53,14 +53,19 @@ const app = new App();
 const stacks = [];
 const isIso = ['us-iso-east-1', 'us-isob-east-1'].includes(config.AWS_REGION);
 
+//Translate is not currently available in us-isob-east1
+const enableTranslate = !['us-isob-east-1'].includes(config.AWS_REGION);
+
 const vpcStack = new VPCStack(app, 'mlspace-vpc', {
     env: envProperties,
     deployCFNEndpoint: true,
     deployCWEndpoint: true,
     deployCWLEndpoint: true,
     deployDDBEndpoint: true,
+    deployEMREndpoint: true,
     deployS3Endpoint: true,
     deploySTSEndpoint: true,
+    deployTranslateEndpoint: enableTranslate,
     isIso,
     mlspaceConfig: config
 });
@@ -78,9 +83,6 @@ const dataBucketName = `${config.DATA_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
 const websiteBucketName = `${config.WEBSITE_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
 const cwlBucketName = `${config.LOGS_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
 const accessLogsBucketName = `${config.ACCESS_LOGS_BUCKET_NAME}-${config.AWS_ACCOUNT}`;
-
-//Translate is not currently available in us-isob-east1
-const enableTranslate = !['us-isob-east-1'].includes(config.AWS_REGION);
 
 const iamStack = new IAMStack(app, 'mlspace-iam', {
     env: envProperties,

--- a/lib/constructs/vpcConstruct.ts
+++ b/lib/constructs/vpcConstruct.ts
@@ -142,6 +142,20 @@ export class VPCConstruct extends Construct {
                     privateDnsEnabled: true,
                 });
             }
+
+            if (props.deployTranslateEndpoint && !props.isIso) {
+                this.vpc.addInterfaceEndpoint('mlspace-translate-interface-endpoint', {
+                    service: InterfaceVpcEndpointAwsService.TRANSLATE,
+                    privateDnsEnabled: true,
+                });
+            }
+
+            if (props.deployEMREndpoint && !props.isIso) {
+                this.vpc.addInterfaceEndpoint('mlspace-emr-interface-endpoint', {
+                    service: InterfaceVpcEndpointAwsService.EMR,
+                    privateDnsEnabled: true,
+                });
+            }
         }
         
         this.vpcSecurityGroup = SecurityGroup.fromSecurityGroupId(

--- a/lib/stacks/vpc.ts
+++ b/lib/stacks/vpc.ts
@@ -24,8 +24,10 @@ export type VPCStackProps = {
     readonly deployCWEndpoint: boolean;
     readonly deployCWLEndpoint: boolean;
     readonly deployDDBEndpoint: boolean;
+    readonly deployEMREndpoint: boolean;
     readonly deployS3Endpoint: boolean;
     readonly deploySTSEndpoint: boolean;
+    readonly deployTranslateEndpoint: boolean;
     readonly isIso?: boolean;
     readonly mlspaceConfig: MLSpaceConfig;
 } & StackProps;
@@ -46,6 +48,5 @@ export class VPCStack extends Stack {
         this.vpc = vpcConstruct.vpc;
         this.vpcSecurityGroupId = vpcConstruct.vpcSecurityGroupId;
         this.vpcSecurityGroup = vpcConstruct.vpcSecurityGroup;
-
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This update enhances MLSpace VPC creation by automatically adding region-appropriate VPC endpoints for AWS Translate and AWS EMR. By routing service traffic through VPC endpoints, we improve the security posture of MLSpace deployments by reducing reliance on public internet access for these services.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
