### PR TITLE
fixed dataset-scope issue when naming S3 URIs

### DIFF
--- a/frontend/src/shared/util/auth-utils.ts
+++ b/frontend/src/shared/util/auth-utils.ts
@@ -24,7 +24,7 @@ import { useAuth } from '../auth/hooks';
 export const  useUsername = (): string => {
     const auth = useAuth();
     
-    const username = auth.user?.displayName;
+    const username = auth.user?.id;
     if (!username) {
         throw new Error('No username available.');
     }


### PR DESCRIPTION
### Problem

The useUsername hook was returning auth.user.displayName instead of auth.user.id. For users whose display name differs from their user ID, this caused private dataset S3 URIs to be constructed with the wrong scope, making datasets inaccessible or 
stored under incorrect paths.

### Change

Updated useUsername in frontend/src/shared/util/auth-utils.ts to return auth.user.id instead of auth.user.displayName.

### Impact

useUsername is consumed by 7 components:

- **Dataset operations** (dataset-create, dataset-selector, dataset-browser) — Private dataset S3 scope now correctly uses user ID. This is the primary fix.
- **Job creation** (training-job-create, hpo-job-create) — UserName payload field sent to backend now uses user ID.
- **Project actions** (project-detail.actions) — "Leave Project" API call now sends user ID.
- **Batch translate** (batch-translate-create) — Used only as a useEffect dependency; no functional change.

### Testing

- Existing unit test in auth-utils.spec.ts passes (mock uses identical values for id and displayName).
- Manual verification performed on creating datasets, viewing datasets, and creating HPO and GT jobs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
