### PR TITLE
Add "Workforce labeling portal" to GT job details for viewing and

### DIFF
--- a/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
+++ b/backend/src/ml_space_lambda/labeling_job/lambda_functions.py
@@ -42,6 +42,13 @@ sagemaker = boto3.client("sagemaker", config=retry_config)
 resource_metadata_dao = ResourceMetadataDAO()
 project_user_dao = ProjectUserDAO()
 
+_labeling_portal_domain_map = {
+    "us-iso-east-1": "labeling.us-iso-east-1.sagemaker.c2s.ic.gov",
+    "us-isob-east-1": "labeling.us-isob-east-1.sagemaker.sc2s.sgov.gov",
+    "us-isof-south-1": "labeling.us-isof-south-1.sagemaker.csp.hci.ic.gov",
+    "us-isof-east-1": "labeling.us-isof-east-1.sagemaker.csp.hci.ic.gov",
+}
+
 
 @api_wrapper
 def describe(event, context):
@@ -68,6 +75,22 @@ def list_workteams(event, context):
             result["Workteams"],
         )
     )
+
+
+@api_wrapper
+def get_workforce_portal_url(event, context):
+    workforce = sagemaker.describe_workforce(WorkforceName="default")["Workforce"]
+    sub_domain = workforce.get("SubDomain", "")
+    if not sub_domain:
+        return {"PortalUrl": ""}
+    # Full hostname returned (e.g. newer API responses)
+    if "." in sub_domain:
+        return {"PortalUrl": f"https://{sub_domain}"}
+    # Short subdomain — construct the portal URL using the region's labeling domain
+    session = boto3.session.Session()
+    region = session.region_name
+    labeling_domain = _labeling_portal_domain_map.get(region, f"labeling.{region}.sagemaker.aws")
+    return {"PortalUrl": f"https://{sub_domain}.{labeling_domain}"}
 
 
 @api_wrapper

--- a/frontend/src/entities/jobs/labeling/detail/labeling-job-detail.tsx
+++ b/frontend/src/entities/jobs/labeling/detail/labeling-job-detail.tsx
@@ -20,6 +20,7 @@ import {
     SpaceBetween,
     Header,
     Button,
+    Link,
     StatusIndicator,
 } from '@cloudscape-design/components';
 import React, { useEffect, ReactNode, useState } from 'react';
@@ -42,18 +43,28 @@ import DetailsContainer from '../../../../modules/details-container';
 import { useBackgroundRefresh } from '../../../../shared/util/hooks';
 import { JobStatus } from '../../job.model';
 import ContentLayout from '../../../../shared/layout/content-layout';
+import axios from '../../../../shared/util/axios-utils';
 
 export function LabelingJobDetail () {
     const { projectName, jobName } = useParams();
     const labelingJob: ILabelingJob = useAppSelector(selectLabelingJob);
     const loadingJobDetails = useAppSelector(loadingLabelingJobDetails);
     const [initialLoaded, setInitialLoaded] = useState(false);
+    const [portalUrl, setPortalUrl] = useState('');
 
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
 
     scrollToPageHeader();
     DocTitle('Labeling Job Details: ', jobName);
+
+    useEffect(() => {
+        if (projectName) {
+            axios.get<{PortalUrl: string}>(`project/${projectName}/jobs/labeling/workforce-portal-url`)
+                .then((response) => setPortalUrl(response.data.PortalUrl))
+                .catch(() => setPortalUrl(''));
+        }
+    }, [projectName]);
 
     useEffect(() => {
         dispatch(describeLabelingJob(String(jobName)))
@@ -101,6 +112,12 @@ export function LabelingJobDetail () {
     labelingJobSettings.set('ARN', labelingJob.LabelingJobArn);
     labelingJobSettings.set('Output dataset location', labelingJob.OutputConfig?.S3OutputPath);
     labelingJobSettings.set('Workteam ARN', labelingJob.HumanTaskConfig?.WorkteamArn);
+    labelingJobSettings.set(
+        'Workforce labeling portal',
+        portalUrl ? (
+            <Link external href={portalUrl}>{portalUrl}</Link>
+        ) : '-'
+    );
     labelingJobSettings.set('Task type', getLabelingJobType(labelingJob));
 
     return (

--- a/lib/constructs/api/projectsConstruct.ts
+++ b/lib/constructs/api/projectsConstruct.ts
@@ -180,6 +180,13 @@ export class ProjectsApiConstruct extends Construct {
                 method: 'GET',
             },
             {
+                name: 'get_workforce_portal_url',
+                resource: 'labeling_job',
+                description: 'Gets the workforce portal URL',
+                path: 'project/{projectName}/jobs/labeling/workforce-portal-url',
+                method: 'GET',
+            },
+            {
                 name: 'list_resources',
                 resource: 'notebook',
                 description: 'List all notebook instances in MLSpace',

--- a/lib/constructs/iamConstruct.ts
+++ b/lib/constructs/iamConstruct.ts
@@ -215,6 +215,7 @@ export class IAMConstruct extends Construct {
                         'ec2:DescribeSecurityGroups',
                         'ec2:DescribeVpcs',
                         // SageMaker list actions that are not bound by resource identifier.
+                        'sagemaker:DescribeWorkforce',
                         'sagemaker:DescribeWorkteam',
                         'sagemaker:ListEndpointConfigs',
                         'sagemaker:ListEndpoints',


### PR DESCRIPTION
## Add Workforce Portal URL to Labeling Job Detail Page

Adds the Ground Truth workforce portal URL to the labeling job detail/preview page so users 
can quickly navigate to the labeling portal directly from a job's details.

### What changed
- **Backend**: Added get_workforce_portal_url endpoint to the existing labeling job lambda. 
It calls sagemaker:DescribeWorkforce to resolve the portal subdomain and returns the full 
URL.
- **Frontend**: The labeling job detail page fetches the portal URL on load and displays it 
as an external link right after "Workteam ARN".
- **Infrastructure**: Added the new API Gateway route (GET .../labeling/workforce-portal-url
) on the existing labeling_job resource and added sagemaker:DescribeWorkforce to the lambda 
IAM policy.

### Notes
- If no private workforce is configured, the field gracefully shows -.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
